### PR TITLE
[codex] fix sales pricing and add SEO content hub

### DIFF
--- a/data/blog/como-elegir-calcetines-tradicionales-calidad.ca.md
+++ b/data/blog/como-elegir-calcetines-tradicionales-calidad.ca.md
@@ -1,0 +1,74 @@
+---
+slug: como-elegir-calcetines-tradicionales-calidad
+title: "Com triar calcetins tradicionals de qualitat"
+excerpt: "Guia pràctica per triar calcetins tradicionals valencians segons materials, talla, disseny, ús i nivell de personalització."
+author: "Equip La Tortugueta"
+date: "2026-04-04"
+tags:
+  - guia de compra
+  - calcetins tradicionals
+  - qualitat
+  - indumentària valenciana
+---
+
+Triar calcetins tradicionals de qualitat no consisteix només a quedar-se amb el primer disseny que pareix bonic. Quan una peça forma part de la indumentària tradicional, la decisió té més capes: material, talla, proporció, color i context importen molt. A La Tortugueta treballem amb estes preguntes cada dia, i per això aquesta guia reuneix els punts bàsics per ajudar-te a decidir millor.
+
+Si abans vols una visió més general, pots combinar este article amb la nostra guia de [calcetins tradicionals valencians](/ca/calcetines-tradicionales).
+
+## 1. Comença per l’ús real
+
+La primera pregunta no és “quin model m’agrada més?”, sinó “per a què el necessite?”. Un parell pensat per a actes freqüents no és el mateix que una peça per a una ocasió especial, una recreació històrica o un conjunt molt concret.
+
+Quan l’ús està clar, la decisió millora molt. Pots valorar si et convé una peça sòbria i versàtil o un disseny amb més presència visual. També és més fàcil anticipar comoditat, resistència i durabilitat.
+
+## 2. Mira bé els materials
+
+El material influeix més del que pareix. Un bon fil millora el tacte, la durabilitat i l’estabilitat del color. També canvia com envellix la peça i com respon després de molts usos i rentats.
+
+Per això, un calcetí tradicional de qualitat no s’hauria de jutjar només per una foto. Convindrà saber quin tipus de fil utilitza el taller, si el teixit és equilibrat i si la peça està pensada per a un ús real.
+
+## 3. La talla importa
+
+Inclús una peça preciosa perd valor si no ajusta bé. Un calcetí massa solt altera l’equilibri del conjunt i pot resultar incòmode. Un de massa ajustat pot deformar el dibuix o resultar molest durant moltes hores.
+
+L’avantatge de treballar amb un taller a mida és que la talla no es tracta com un número genèric. Es pot revisar la talla real del peu, l’alçada de canya o altres detalls abans de produir. Si tens dubtes, el millor és escriure’ns des de [contacte](/contacto) abans de fer la comanda.
+
+## 4. Tria el disseny pensant en el conjunt
+
+Un error molt habitual és triar el calcetí aïlladament. Però en la indumentària tradicional tot dialoga. El calcetí ha de funcionar amb els teixits, colors i proporcions del conjunt.
+
+Per això aconsellem revisar primer el to general de la indumentària i després decidir si el calcetí ha d’acompanyar amb discreció o aportar contrast. En alguns casos funciona millor un model llis o equilibrat; en altres té més sentit una peça amb més caràcter. Si estàs en eixe punt, la [carta de colors](/colores) t’ajudarà molt.
+
+## 5. Distingix entre artesania real i aparença decorativa
+
+No tot allò que sembla artesanal ho és de veritat. A voltes una peça es presenta com a “tradicional” només per un nom suggeridor o per un dibuix recognoscible. La qualitat real depén de com s’ha pensat i confeccionat: material, patró, acabat, comoditat i coherència amb l’estètica original.
+
+Això és encara més important si busques una reproducció històrica o una peça inspirada en una referència antiga. En eixos casos, l’aparença superficial no és suficient.
+
+## 6. Quan val la pena personalitzar
+
+Personalitzar no vol dir necessàriament fer una peça extravagant. Moltes vegades significa resoldre bé una necessitat concreta: ajustar la talla, afinar un to, recuperar una referència familiar o trobar la millor combinació per a una indumentària determinada.
+
+Quan es fa amb criteri, la personalització millora molt el resultat. Converteix el catàleg en un punt de partida flexible i no en una llista tancada.
+
+## 7. Senyals que solen indicar qualitat
+
+Aquestes pistes solen ajudar:
+
+1. El teixit es percep equilibrat i consistent.
+2. Els colors semblen triats amb intenció.
+3. El taller et pot orientar sobre talla, material i ús.
+4. El disseny encaixa amb la indumentària sense efecte disfressa.
+5. La peça està pensada per durar i per vestir-se còmodament.
+
+## 8. Un recorregut útil abans de decidir
+
+Aquest ordre sol funcionar molt bé:
+
+1. Llig la guia de [calcetins tradicionals valencians](/ca/calcetines-tradicionales).
+2. Revisa el [catàleg](/ca#catalogo) i compara models.
+3. Utilitza la [carta de colors](/colores) si necessites ajustar combinacions.
+4. Llig l’article sobre la [història dels calcetins tradicionals valencians](/ca/blog/historia-calcetines-tradicionales-valencianos) per tindre més context cultural.
+5. Escriu-nos des de [contacte](/contacto) si vols orientació personal.
+
+Triar millor també és vestir millor. Un bon calcetí tradicional no funciona només perquè siga bonic, sinó perquè està ben fet, ben ajustat i ben triat per a qui el vestirà.

--- a/data/blog/como-elegir-calcetines-tradicionales-calidad.en.md
+++ b/data/blog/como-elegir-calcetines-tradicionales-calidad.en.md
@@ -1,0 +1,74 @@
+---
+slug: como-elegir-calcetines-tradicionales-calidad
+title: "How to choose high-quality traditional socks"
+excerpt: "A practical guide to choosing traditional Valencian socks by material, fit, design, use and level of customisation."
+author: "La Tortugueta Team"
+date: "2026-04-04"
+tags:
+  - buying guide
+  - traditional socks
+  - quality
+  - Valencian dress
+---
+
+Choosing high-quality traditional socks is not just about picking the first attractive design. When a garment belongs to traditional dress, the decision carries more layers: material, fit, proportion, colour and context all matter. At La Tortugueta we work with those questions every day, so this guide gathers the basics that help you choose with more confidence.
+
+If you want the broader picture first, you can pair this article with our guide to [traditional Valencian socks](/en/calcetines-tradicionales).
+
+## 1. Start with the real use
+
+The first question is not “which model do I like most?” but “what do I need it for?”. A pair intended for regular events is not the same as one meant for a special occasion, a historical recreation or a very specific outfit. The answer shapes everything else.
+
+Once the real use is clear, the decision becomes easier. You can judge whether you need something sober and versatile or a design with stronger visual presence. You can also better anticipate durability, comfort and how important resistance will be over long wear.
+
+## 2. Look carefully at materials
+
+Material has more influence than it may seem. A good yarn improves feel, durability and colour stability. It also changes how the sock ages and how it behaves after repeated washing and use.
+
+That is why a high-quality traditional sock should not be judged only from a photo. It helps to know what kind of yarn the workshop uses, how balanced the fabric feels and whether the maker understands the practical role of the piece.
+
+## 3. Fit matters
+
+Even a beautiful piece loses value if it does not fit well. A sock that is too loose changes the balance of the whole outfit and can feel uncomfortable. One that is too tight may distort the design or feel unpleasant during long wear.
+
+The advantage of working with a made-to-order workshop is that fit is not treated as a generic number. Real foot size, leg height or other small details can be reviewed before production. If you are unsure, the best step is to contact us through [contact](/contacto) before placing the order.
+
+## 4. Choose the design in relation to the whole outfit
+
+One common mistake is choosing the sock in isolation. In traditional dress, however, everything speaks to everything else. The sock needs to work with the textiles, colours and proportions of the whole ensemble.
+
+That is why we recommend first reviewing the general mood of the outfit and then deciding whether the sock should accompany quietly or provide contrast. In some cases a plain or balanced model works best; in others a bolder design makes more sense. If you are in that stage, the [colour chart](/colores) is a helpful tool.
+
+## 5. Separate true craftsmanship from decorative appearance
+
+Not everything that looks artisanal truly is. Sometimes a piece is presented as “traditional” simply because of a suggestive name or a recognisable pattern. Real quality depends on how the garment is conceived and made: material, pattern, finish, comfort and coherence with the original aesthetics.
+
+That matters even more if you want a historical reproduction or a piece inspired by an old reference. In those cases, surface appearance is not enough. The workshop needs to understand the logic of the model and the role it plays within the outfit.
+
+## 6. When customisation is worth it
+
+Customisation does not necessarily mean making something extravagant. Very often it means solving a concrete need well: adjusting fit, refining a tone, recovering a family reference or finding the right combination for a particular outfit.
+
+When done properly, customisation improves the result enormously. It turns the catalogue into a flexible starting point instead of a closed list.
+
+## 7. Signs that usually indicate quality
+
+These signals often help identify a strong traditional sock:
+
+1. The knit feels balanced and consistent.
+2. Colour choices feel intentional.
+3. The workshop can advise you on fit, material and use.
+4. The design fits traditional dress without looking costume-like.
+5. The piece is made to last and to be worn comfortably.
+
+## 8. A useful route before you decide
+
+This sequence usually works well:
+
+1. Read the guide to [traditional Valencian socks](/en/calcetines-tradicionales).
+2. Visit the [catalogue](/en#catalogo) and compare models.
+3. Use the [colour chart](/colores) if you need to refine combinations.
+4. Read our article on the [history of traditional Valencian socks](/en/blog/historia-calcetines-tradicionales-valencianos) for more cultural context.
+5. Write to us through [contact](/contacto) if you want personal guidance.
+
+Choosing better is also dressing better. A good traditional sock is not only visually appealing; it works because it is well made, well fitted and well chosen for the person who will wear it.

--- a/data/blog/como-elegir-calcetines-tradicionales-calidad.es.md
+++ b/data/blog/como-elegir-calcetines-tradicionales-calidad.es.md
@@ -1,0 +1,82 @@
+---
+slug: como-elegir-calcetines-tradicionales-calidad
+title: "Cómo elegir calcetines tradicionales de calidad"
+excerpt: "Guía práctica para elegir calcetines tradicionales valencianos según materiales, talla, diseño, uso y nivel de personalización."
+author: "Equipo La Tortugueta"
+date: "2026-04-04"
+tags:
+  - guía de compra
+  - calcetines tradicionales
+  - calidad
+  - indumentaria valenciana
+---
+
+Elegir calcetines tradicionales de calidad no consiste únicamente en mirar el dibujo o quedarse con el primer modelo que “queda bonito”. Cuando una pieza forma parte de la indumentaria tradicional, la decisión tiene más matices: importa el material, la talla, la proporción, el color y también el contexto en el que se va a usar. En La Tortugueta trabajamos a diario con esa realidad, así que hemos reunido aquí una guía práctica para ayudarte a elegir con más criterio.
+
+Si quieres una visión más general de la colección y del enfoque del taller, puedes complementar esta lectura con nuestra página sobre [calcetines tradicionales valencianos](/calcetines-tradicionales).
+
+## 1. Empieza por el uso real
+
+La primera pregunta no es “qué modelo me gusta más”, sino “para qué lo necesito”. No es lo mismo un par pensado para actos frecuentes que uno destinado a una ocasión especial, una recreación histórica o un conjunto muy concreto. Tampoco es igual vestir fallas que participar en un grupo de danses o completar una indumentaria inspirada en una referencia familiar.
+
+Cuando el uso está claro, la elección mejora mucho. Sabes si te conviene algo sobrio, más versátil y fácil de combinar, o si tiene sentido apostar por un diseño con más presencia visual. También puedes anticipar mejor el desgaste, la importancia de la resistencia del hilo y la necesidad de un ajuste cómodo durante muchas horas.
+
+## 2. Mira los materiales con atención
+
+El material condiciona el resultado final más de lo que parece. Un buen hilo aporta suavidad, durabilidad y una respuesta cromática más estable. También influye en cómo se comporta el calcetín con el paso del tiempo: si mantiene mejor el color, si resiste el lavado o si conserva la estructura sin deformarse.
+
+Por eso, un calcetín tradicional de calidad no debería evaluarse solo por el aspecto en una foto. Conviene fijarse en la procedencia del hilo, en la consistencia del tejido y en si el taller trabaja materiales adecuados para el tipo de pieza que ofrece. En nuestro caso, cuidamos mucho ese equilibrio entre presencia visual y resistencia, porque sabemos que muchas de estas piezas están hechas para vestirse de verdad, no solo para fotografiarse.
+
+## 3. La talla importa más de lo que parece
+
+Una buena pieza puede perder todo su valor si no ajusta bien. Un calcetín demasiado suelto cambia la lectura del conjunto y resulta incómodo. Uno demasiado justo también puede deformar el dibujo o provocar una sensación incómoda durante el uso.
+
+La ventaja de trabajar con un taller que confecciona bajo pedido es que la talla no se trata como un número genérico. Se puede revisar el pie real, la altura de la caña o incluso pequeñas particularidades del encargo. Esa atención evita muchos errores comunes y marca una diferencia clara respecto a soluciones totalmente estandarizadas.
+
+Si tienes dudas sobre tallaje o necesitas una recomendación concreta, lo mejor es escribirnos desde [contacto](/contacto) antes de confirmar el pedido.
+
+## 4. Elige el diseño pensando en el conjunto
+
+Uno de los errores más habituales es escoger el calcetín de forma aislada. Sin embargo, en indumentaria tradicional todo dialoga. El calcetín tiene que convivir con tejidos, colores y proporciones del resto del conjunto. Un diseño puede ser precioso por sí solo y, aun así, no ser la mejor elección para una combinación concreta.
+
+Por eso aconsejamos revisar primero el tono general de la indumentaria y decidir después si el calcetín debe acompañar con discreción o aportar contraste. En algunos casos funciona mejor un modelo liso o muy equilibrado; en otros, tiene más sentido recurrir a una pieza con mayor carácter. Si estás en ese proceso, la [carta de colores](/colores) es una herramienta muy útil para ordenar ideas.
+
+## 5. Diferencia entre artesanía real y simple acabado decorativo
+
+No todo lo que parece artesanal lo es de verdad. A veces una pieza se presenta como “tradicional” solo porque usa un nombre sugerente o un dibujo reconocible. Pero la calidad real está en cómo se ha pensado y producido: materiales, patrón, acabado, ajuste y coherencia con la estética original.
+
+Eso es especialmente importante si buscas una reproducción histórica o una pieza inspirada en referencias antiguas. Ahí no basta con un aspecto superficial. Hace falta entender la lógica del modelo, su proporción, su textura y el papel que cumple dentro del conjunto.
+
+En [quiénes somos](/quienes-somos) contamos precisamente esa parte del trabajo: cómo documentamos, cómo traducimos referencias antiguas y por qué defendemos un enfoque artesanal con criterio.
+
+## 6. Personalización: cuándo merece la pena
+
+La personalización no siempre significa hacer algo extravagante. A menudo consiste en resolver bien una necesidad concreta: adaptar una talla, ajustar el tono, recuperar un diseño familiar o encontrar la combinación que mejor encaja con una indumentaria determinada.
+
+Cuando se hace con sentido, la personalización mejora mucho el resultado. Convierte el catálogo en un punto de partida flexible y no en una lista cerrada. Eso sí, conviene apoyarse en referencias claras: fotos, colores aproximados, contexto de uso y cualquier detalle que ayude a interpretar bien el encargo.
+
+## 7. Qué señales suelen indicar calidad
+
+Estas son algunas pistas que suelen ayudarte a detectar un buen calcetín tradicional:
+
+1. El tejido se percibe equilibrado y consistente.
+2. El color tiene intención y no parece elegido al azar.
+3. El taller puede orientarte sobre talla, materiales y contexto de uso.
+4. El diseño encaja con la estética tradicional sin caer en un efecto disfraz.
+5. La pieza está pensada para durar y para vestirse con comodidad.
+
+## 8. Un recorrido útil antes de decidir
+
+Si estás a punto de elegir, este recorrido suele funcionar muy bien:
+
+1. Revisa la guía principal de [calcetines tradicionales valencianos](/calcetines-tradicionales).
+2. Entra al [catálogo](/#catalogo) y guarda los modelos que más encajen contigo.
+3. Consulta la [carta de colores](/colores) si necesitas ajustar tonos.
+4. Lee también la [historia de los calcetines tradicionales valencianos](/blog/historia-calcetines-tradicionales-valencianos) si quieres más contexto cultural.
+5. Escríbenos por [contacto](/contacto) para resolver cualquier duda antes de pedir.
+
+## Elegir mejor es vestir mejor
+
+Un calcetín tradicional de calidad no llama la atención solo por ser bonito. Convence porque está bien pensado, bien tejido y bien elegido para la persona que lo va a llevar. Esa es la diferencia entre una compra apresurada y una pieza con verdadero sentido dentro de la indumentaria.
+
+En La Tortugueta creemos que elegir bien también forma parte del oficio. Por eso combinamos catálogo, documentación, color y atención personal. Si quieres empezar a explorar modelos concretos, vuelve a nuestra página de [calcetines tradicionales valencianos](/calcetines-tradicionales) o entra directamente en el [catálogo](/#catalogo).

--- a/data/blog/historia-calcetines-tradicionales-valencianos.ca.md
+++ b/data/blog/historia-calcetines-tradicionales-valencianos.ca.md
@@ -1,0 +1,64 @@
+---
+slug: historia-calcetines-tradicionales-valencianos
+title: "Història dels calcetins tradicionals valencians"
+excerpt: "Un recorregut per l’origen, l’evolució i la vigència actual dels calcetins tradicionals valencians dins de la indumentària i l’artesania tèxtil."
+author: "Equip La Tortugueta"
+date: "2026-04-04"
+tags:
+  - història
+  - calcetins tradicionals
+  - indumentària valenciana
+  - artesania
+---
+
+Parlar de calcetins tradicionals valencians és parlar d’una peça que pot semblar menuda, però que conté molta memòria cultural. Forma part d’un llenguatge més ampli: el de la indumentària, l’ofici tèxtil i el record familiar. A La Tortugueta treballem just en eixe punt de trobada entre arxiu, ús i artesania. Per això, quan algú ens pregunta per la història d’estes peces, no pensem només en dates o modes, sinó en una continuïtat viva que encara té sentit hui.
+
+Si abans de triar un model vols una visió més pràctica, et recomanem combinar esta lectura amb la nostra guia sobre [calcetins tradicionals valencians](/ca/calcetines-tradicionales), on reunim col·lecció, preguntes habituals i una selecció de peces actuals.
+
+## Un origen lligat a la necessitat i a l’ofici
+
+Durant segles, cobrir el peu i la cama va ser una qüestió pràctica: abrigar, protegir i donar comoditat. Però dins de la indumentària valenciana, com en altres tradicions tèxtils europees, eixa funció va anar guanyant també valor visual i simbòlic. La mitja o calça va passar a ser una peça útil, però també visible i significativa dins del conjunt.
+
+Això ajuda a entendre per què les referències antigues parlen de mitges llises, ratllades, amb inicials, motius geomètrics o brodats més elaborats. Algunes peces eren discretes; altres, ornamentals. La diferència depenia sovint del context, de la posició social o de l’ús concret.
+
+## Del treball manual a la tradició documentada
+
+La història de la calceteria està molt vinculada a la història de la fabricació. Primer hi hagué el teixit manual; després arribaren els telers i les màquines especialitzades, que canviaren la velocitat de producció i ampliaren les possibilitats de disseny. Tot i això, la industrialització no va esborrar la lògica artesanal de la indumentària tradicional. Continuava sent fonamental saber triar el fil, entendre el dibuix i resoldre bé la forma final.
+
+En el context valencià, este saber tèxtil va acabar formant part d’un patrimoni material i immaterial més ampli. Els calcetins tradicionals no s’entenen aïllats. Formen part de la mateixa cultura del detall que afecta faldes, gipons, davantals, mocadors i altres peces. Tot ha de dialogar entre si. Per això, una reproducció històrica ben feta ha de fer més que “semblar antiga”: ha d’entendre la funció de la peça dins del conjunt.
+
+## Materials, color i disseny
+
+Una de les coses més interessants dels calcetins tradicionals valencians és la seua varietat. No hi ha una única fórmula vàlida. Canvien la llargària, el gruix, la decoració i la presència del color. Alguns dissenys són sobris; altres tenen una presència més ornamental.
+
+El material ací és fonamental. Un bon fil millora el tacte, la durabilitat i l’estabilitat del color. També condiciona com envellix la peça i com respon després de molts usos i rentats. Per això, a La Tortugueta donem molta importància a la selecció cromàtica i a la conversa prèvia abans de confirmar l’encàrrec.
+
+Si encara estàs comparant tons i combinacions, la nostra [carta de colors](/colores) és un bon lloc per començar.
+
+## El seu lloc dins de la indumentària valenciana
+
+Els calcetins tradicionals valencians tenen sentit perquè formen part d’una manera de vestir on les proporcions, els acabats i el color importen molt. En falles, grups de danses o recreació històrica, un calcetí mal triat pot trencar l’equilibri del conjunt. Quan està ben triat, en canvi, reforça la coherència visual.
+
+Eixa relació amb la indumentària és una de les raons per les quals estes peces continuen sent actuals. No són peces de museu ni records decoratius. Són peces útils, carregades de significat per a qui vol vestir tradició amb respecte i criteri.
+
+## De l’arxiu a l’ús present
+
+En el nostre cas, el treball sovint comença amb fotografies antigues, col·leccions particulars o encàrrecs que demanen reproduir un model concret. Això obliga a mirar amb calma: proporcions, tons, detalls i estructura. La història no es conserva només guardant objectes; també mantenint viu el coneixement necessari per a refer-los bé.
+
+Esta manera de treballar és part del que expliquem en [qui som](/ca/quienes-somos): la història del taller, el camí de Macu Garcia i la manera en què La Tortugueta es mou entre documentació, ofici i encàrrec personalitzat.
+
+## Per què continuen important
+
+L’interés per allò artesanal ha crescut, però no tot allò que es presenta com a artesanal és automàticament rigorós o valuós. En els calcetins tradicionals valencians, allò important no és només l’aspecte antic, sinó la coherència de la peça: material, patró, acabat, comoditat i fidelitat visual.
+
+Per això defensem una idea senzilla: la tradició no és immobilitat. És continuïtat amb criteri. Un bon calcetí tradicional connecta amb el passat i alhora resol una necessitat actual. Es pot vestir hui, ajustar a una talla real i personalitzar sense perdre la lògica que el fa recognoscible.
+
+## Per on continuar
+
+Si vols passar de la història a la pràctica, este recorregut funciona molt bé:
+
+1. Visita la guia de [calcetins tradicionals valencians](/ca/calcetines-tradicionales).
+2. Revisa el [catàleg](/ca#catalogo) i compara models.
+3. Escriu-nos des de [contacte](/contacto) si tens una referència antiga, un dubte de talla o un encàrrec personalitzat.
+
+La història d’estes peces continua escrivint-se cada vegada que algú tria ofici, memòria i cura per damunt d’una solució genèrica.

--- a/data/blog/historia-calcetines-tradicionales-valencianos.en.md
+++ b/data/blog/historia-calcetines-tradicionales-valencianos.en.md
@@ -1,0 +1,64 @@
+---
+slug: historia-calcetines-tradicionales-valencianos
+title: "History of traditional Valencian socks"
+excerpt: "A journey through the origin, evolution and current relevance of traditional Valencian socks within dress culture and textile craft."
+author: "La Tortugueta Team"
+date: "2026-04-04"
+tags:
+  - history
+  - traditional socks
+  - Valencian dress
+  - craftsmanship
+---
+
+Talking about traditional Valencian socks means talking about a garment that may seem modest, yet carries a remarkable cultural weight. It belongs to the wider language of dress, textile skill and family memory. At La Tortugueta we work precisely at that crossroads between archive, use and craft. That is why, when someone asks about the history of these pieces, we do not think only of dates or styles, but of a living continuity that still makes sense today.
+
+If you want a practical overview before choosing a model, we recommend pairing this article with our guide to [traditional Valencian socks](/en/calcetines-tradicionales), where we gather the collection, common questions and a curated selection of current pieces.
+
+## Origins rooted in need and skill
+
+For centuries, covering the foot and the leg was first of all a practical matter: warmth, protection and comfort. But in Valencian dress, as in many textile traditions across Europe, that practical role gradually gained visual and symbolic depth. The stocking or sock became not only useful, but also visible and meaningful within the outfit.
+
+That helps explain why historical references mention plain stockings, striped ones, initials, geometric motifs and more elaborate embroidery. Some pieces were discreet, some were decorative, and the difference often reflected context, social position or intended use. Function and ornament coexisted naturally.
+
+## From manual work to documented tradition
+
+The history of hosiery is closely tied to the history of making. Hand knitting came first; later, frames and specialised machines changed the speed of production and widened the range of designs that could be achieved. Even so, industrialisation did not erase the artisanal logic behind traditional dress. A great deal still depended on practical knowledge: how to choose the yarn, how to read a pattern and how to shape the final piece well.
+
+In the Valencian context, this textile knowledge became part of a wider material and immaterial heritage. Traditional socks do not stand alone. They belong to the same culture of detail that shapes skirts, bodices, aprons, shawls and other dress elements. Everything needs to speak to everything else. That is why a historical reproduction should do more than merely “look old”: it should understand the role the piece played inside the whole outfit.
+
+## Materials, colour and design
+
+One of the most interesting things about traditional Valencian socks is their variety. There is no single valid formula. Length, thickness, decoration and colour presence all change from one piece to another. Some designs are restrained; others are more expressive and decorative.
+
+Material matters deeply here. A good yarn improves touch, durability and colour stability. It also changes how the piece ages and how it behaves after repeated washing and wear. For that reason, at La Tortugueta we place strong emphasis on colour selection and on the conversation that happens before an order is confirmed.
+
+If you are still comparing tones and combinations, our [colour chart](/colores) is a useful place to start.
+
+## Their place in Valencian dress
+
+Traditional Valencian socks make sense because they belong to a wider way of dressing in which proportion, finish and colour all matter. In fallas, dance groups or historical reenactment, a poorly chosen sock can disturb the balance of the whole outfit. When the sock is well chosen, it strengthens the visual coherence of the ensemble.
+
+That relationship with dress is one of the reasons these pieces remain relevant today. They are not museum relics or decorative souvenirs. They are functional garments with cultural meaning, especially for people who want to dress tradition with seriousness and care.
+
+## From archive to present-day use
+
+In our case, the work often starts with old photographs, private collections or requests to reproduce a specific model. That demands careful observation: proportions, tones, details and structure all need to be studied before being translated into a piece that makes sense today. History is preserved not only by storing objects, but also by keeping alive the knowledge required to remake them properly.
+
+That approach is part of what we explain in [about us](/en/quienes-somos): the story of the workshop, the path of Macu Garcia and the way La Tortugueta works between documentation, craft and bespoke orders.
+
+## Why they still matter
+
+Interest in artisanal work has grown in recent years, but not everything labelled “artisanal” is automatically meaningful or accurate. In traditional Valencian socks, what matters is not only the old-fashioned look, but the coherence of the piece: material, pattern, finish, comfort and visual truthfulness.
+
+That is why we defend a simple idea: tradition is not immobility. It is continuity with judgement. A well-made traditional sock connects with the past while still solving a present-day need. It can be worn now, adjusted to a real size and personalised without losing the logic that makes it recognisable.
+
+## Where to continue from here
+
+If you want to move from history into practical decision-making, this route works especially well:
+
+1. Visit our guide to [traditional Valencian socks](/en/calcetines-tradicionales).
+2. Browse the [catalogue](/en#catalogo) and compare models.
+3. Contact us through [contact](/contacto) if you have an old reference, a sizing question or a bespoke request.
+
+The history of these garments keeps being written every time someone chooses care, craft and memory over a generic solution.

--- a/data/blog/historia-calcetines-tradicionales-valencianos.es.md
+++ b/data/blog/historia-calcetines-tradicionales-valencianos.es.md
@@ -1,0 +1,64 @@
+---
+slug: historia-calcetines-tradicionales-valencianos
+title: "Historia de los calcetines tradicionales valencianos"
+excerpt: "Un recorrido por el origen, la evolución y la vigencia actual de los calcetines tradicionales valencianos dentro de la indumentaria y la artesanía textil."
+author: "Equipo La Tortugueta"
+date: "2026-04-04"
+tags:
+  - historia
+  - calcetines tradicionales
+  - indumentaria valenciana
+  - artesanía
+---
+
+Hablar de calcetines tradicionales valencianos es hablar de una pieza humilde solo en apariencia. En realidad, forma parte de un lenguaje visual mucho más amplio: el de la indumentaria popular, el oficio textil y la memoria cotidiana de generaciones enteras. En La Tortugueta trabajamos precisamente desde ese cruce entre archivo, uso y artesanía. Por eso, cuando alguien nos pregunta por la historia de estas piezas, no pensamos solo en una fecha o en una moda, sino en una continuidad cultural que todavía hoy sigue viva.
+
+Si has llegado aquí buscando contexto antes de elegir un modelo, te recomendamos empezar también por nuestra guía de [calcetines tradicionales valencianos](/calcetines-tradicionales), donde reunimos la colección, las preguntas más habituales y una selección de piezas actuales.
+
+## Un origen ligado a la necesidad y al oficio
+
+Durante siglos, cubrir pie y pierna tuvo una función práctica evidente: proteger del frío, de la fricción y del desgaste del trabajo diario. Pero en el ámbito valenciano, como en tantas otras tradiciones textiles europeas, esa función fue ganando complejidad estética. La media o calza dejó de ser solamente abrigo para convertirse también en una pieza visible, integrada en el conjunto de la vestimenta.
+
+Eso explica que en muchas referencias antiguas aparezcan medias lisas, rayadas, con iniciales, dibujos geométricos o bordados más elaborados. La pieza podía ser sobria o llamativa según el contexto, la capacidad económica o el uso para el que estaba destinada. No era raro que convivieran soluciones muy funcionales con otras mucho más ornamentales.
+
+## Del trabajo manual a la tradición documentada
+
+La historia de la calcetería está muy ligada a la evolución de las técnicas de tejido. Primero llegaron los trabajos totalmente manuales; más adelante, los telares y máquinas específicas transformaron la velocidad de producción y abrieron nuevas posibilidades formales. Aun así, en el ámbito tradicional, la industrialización no borró del todo la lógica artesanal. Muchas piezas siguieron dependiendo del conocimiento práctico de quienes sabían elegir el hilo, leer el dibujo y resolver la forma final con buen criterio.
+
+En la Comunidad Valenciana, este saber textil convivió con otros oficios y acabó formando parte del patrimonio material e inmaterial. El calcetín tradicional no se entiende sin esa cultura del detalle que también afecta a faldas, jubones, delantales, pañuelos o mantillas. Todo dialoga entre sí. Por eso, cuando hablamos de reproducir un modelo antiguo, no basta con “parecerse”: hay que entender qué estaba haciendo esa pieza dentro del conjunto.
+
+## Materiales, color y diseño
+
+Uno de los rasgos más interesantes de los calcetines tradicionales valencianos es la variedad. No existe una sola solución válida, sino un repertorio de posibilidades. Cambian la longitud, el grosor, la decoración y la presencia del color. Algunas piezas apuestan por la discreción; otras incorporan franjas, contrastes o referencias que hacen más rica la lectura del conjunto.
+
+Aquí el material importa mucho. Un buen hilo no solo mejora la sensación al tacto, también cambia la caída, la resistencia y la forma en la que el color se fija y envejece. Esa es una de las razones por las que en La Tortugueta damos tanta importancia a la selección cromática y a la consulta previa. Antes de tejer, conviene saber con qué piezas se combinará el calcetín y qué presencia se quiere conseguir.
+
+Si estás en ese punto de decisión, la [carta de colores](/colores) puede ayudarte a ver con más claridad las posibilidades reales de combinación.
+
+## La relación con la indumentaria valenciana
+
+Los calcetines tradicionales valencianos no viven aislados. Forman parte de una forma de vestir donde las proporciones, los acabados y los tonos importan. En fallas, danses y recreación histórica, una pieza mal resuelta puede romper el equilibrio de todo el conjunto. En cambio, cuando el calcetín está bien escogido, refuerza la coherencia visual y aporta profundidad.
+
+Esa relación con la indumentaria es una de las razones por las que hoy siguen teniendo sentido. No son una reliquia de museo ni una copia turística. Son una pieza útil, actual y cargada de significado para quien quiere vestir tradición con respeto. A veces el interés nace por una necesidad concreta; otras veces, por el deseo de recuperar una referencia familiar o un modelo visto en una fotografía antigua.
+
+## Del archivo al presente
+
+En nuestro caso, el trabajo parte a menudo de imágenes antiguas, colecciones privadas o encargos que piden reproducir un diseño concreto. Eso obliga a mirar con paciencia: estudiar proporciones, analizar tonos y traducir todo eso a una pieza que tenga sentido hoy. La historia no se conserva solo guardando objetos; también se conserva manteniendo vivo el conocimiento que permite rehacerlos bien.
+
+Esa es una parte importante de lo que contamos en [quiénes somos](/quienes-somos): la historia del taller, la trayectoria de Macu García y la forma en la que La Tortugueta trabaja entre documentación, oficio y encargo personalizado.
+
+## Por qué siguen importando hoy
+
+Hay un interés creciente por todo lo artesanal, pero no todo lo artesanal es automáticamente fiel o valioso. En el caso de los calcetines tradicionales valencianos, lo importante no es solo que la pieza “parezca antigua”, sino que esté bien pensada: que respete la estética, que use materiales adecuados y que responda a una necesidad real de quien la va a vestir.
+
+Por eso defendemos una idea sencilla: la tradición no es inmovilidad. Es continuidad con criterio. Un calcetín tradicional bien hecho conecta con el pasado, pero también resuelve el presente. Se puede vestir hoy, se puede adaptar a una talla concreta y se puede personalizar sin perder la lógica que lo hace reconocible.
+
+## Un buen punto de partida para seguir explorando
+
+Si después de esta lectura quieres pasar de la historia a la práctica, te recomendamos tres pasos:
+
+1. Visitar la página de [calcetines tradicionales valencianos](/calcetines-tradicionales) para ver la guía principal.
+2. Entrar en el [catálogo](/#catalogo) y revisar los modelos disponibles.
+3. Escribirnos desde [contacto](/contacto) si tienes una referencia antigua, dudas sobre talla o quieres un encargo personalizado.
+
+La historia de estas piezas sigue escribiéndose cada vez que alguien decide no conformarse con cualquier calcetín y busca una solución con oficio, memoria y personalidad propia.

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,11 @@ const remotePatterns = [
     protocol: 'https',
     hostname: 'pub-6d7cc19d77b44520a5ac19e77cb47c4e.r2.dev',
     pathname: '/**'
+  },
+  {
+    protocol: 'https',
+    hostname: 'upload.wikimedia.org',
+    pathname: '/**'
   }
 ]
 

--- a/scripts/seo/sync-product-narratives.mjs
+++ b/scripts/seo/sync-product-narratives.mjs
@@ -1,0 +1,186 @@
+import 'dotenv/config'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Missing Supabase environment variables.')
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey)
+
+const narratives = {
+  alzira: {
+    storyTitle: 'Alzira entre naranjos y huerta',
+    storyOrigin: 'Ribera Alta, amaneceres de huerta y terrazas abiertas al Xúquer',
+    storyCost: 'Bordado artesanal pensado para indumentaria tradicional con lectura cromática mediterránea',
+    storyBody:
+      'Alzira despierta con la niebla suave de la huerta y el perfume de los naranjos cuando el día apenas empieza. Este modelo recoge esa calma de la Ribera en una composición de tonos tierra, verdes cítricos y pequeños contrastes que recuerdan los caminos entre bancales. Son calcetines tradicionales valencianos con carácter sereno, hechos para acompañar la indumentaria con la misma elegancia pausada que tiene la ciudad al amanecer.',
+    storyBodyVa:
+      'Alzira s\'obri entre tarongers, horta i llum de la Ribera. Este model arreplega eixa calma amb tons de terra i verds cítrics pensats per a una indumentària valenciana delicada i molt arrelada.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Alzira inspirados en la huerta y los naranjos de la Ribera. Diseño artesanal para indumentaria valenciana.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/e/e3/Oranges_-_whole-halved-segment.jpg',
+      'https://upload.wikimedia.org/wikipedia/commons/2/28/El_riu_X%C3%BAquer_al_seu_pas_per_Fortaleny_%28Pa%C3%ADs_Valenci%C3%A0%29%2C_2.jpg'
+    ]
+  },
+  agullent: {
+    storyTitle: 'Agullent y el silencio de la Vall d\'Albaida',
+    storyOrigin: 'Pueblo de montaña, piedra, cielo abierto y campanas lentas',
+    storyCost: 'Diseño sobrio y equilibrado para vestir tradición sin exceso',
+    storyBody:
+      'Agullent tiene esa belleza de los pueblos que se guardan entre montañas y dejan que el tiempo pase despacio. En este diseño mandan los grises de piedra, los azules anchos del cielo y un pulso cromático más contenido, pensado para quien busca calcetines artesanales valencianos con presencia sobria. El resultado es una pieza serena y firme, muy ligada al paisaje interior y a la elegancia silenciosa de la Vall d\'Albaida.',
+    storyBodyVa:
+      'Agullent viu entre muntanyes i pedra, amb una llum neta i silenciosa. El model aposta per una elegància sòbria, molt pròpia dels pobles d\'interior i de la indumentària ben entesa.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Agullent con inspiración de montaña, piedra y cielo abierto. Artesanía sobria para indumentaria regional.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/6/6c/Agullent._Ajuntament_1.JPG'
+    ]
+  },
+  ador: {
+    storyTitle: 'Ador entre marjal y Mediterráneo',
+    storyOrigin: 'Paisaje húmedo, arrozales, cañas y memoria de costa',
+    storyCost: 'Composición cromática con verdes húmedos y azules lejanos',
+    storyBody:
+      'Ador mira hacia ese territorio donde la tierra mojada y el mar se entienden sin hablar demasiado. El modelo traslada a la calcetería artesanal valenciana los marrones húmedos, los verdes de caña y la intuición azul del Mediterráneo al fondo. Es un diseño con raíz, pensado para quien quiere llevar en la indumentaria un eco de marjal, de tradición agrícola y de paisaje vivido.',
+    storyBodyVa:
+      'Ador respira marjal, canyar i proximitat de mar. El disseny recull eixos verds humits i blaus mediterranis per a donar-li una ànima molt valenciana al conjunt.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Ador inspirados en el marjal y el Mediterráneo. Diseño artesanal con tonos húmedos y raíz valenciana.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/3/3e/Aiguamoll.JPG',
+      'https://upload.wikimedia.org/wikipedia/commons/9/96/Mediterranee_02_EN.jpg'
+    ]
+  },
+  alberri: {
+    storyTitle: 'Alberri, huerta antigua y flor de azahar',
+    storyOrigin: 'Acequias, regadío y memoria agrícola de generaciones',
+    storyCost: 'Diseño de lectura vegetal con blancos suaves y fondo fértil',
+    storyBody:
+      'Alberri suena a huerta trabajada, a agua que corre por acequias y a naranjos que conocen bien el paso de las estaciones. Este modelo toma de ahí su equilibrio: el verde del regadío, el marrón de la tierra fértil y el blanco limpio del azahar en marzo. Son calcetines tradicionales valencianos que traducen el paisaje agrícola en una pieza cálida, delicada y muy fácil de integrar en conjuntos de indumentaria con personalidad.',
+    storyBodyVa:
+      'Alberri evoca séquies, horta fonda i flor de taronger. El model combina verds de regadiu, marrons de terra i blancs suaus per a una peça amb molta memòria valenciana.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Alberri inspirados en la huerta, las acequias y el azahar. Artesanía con tonos fértiles y mediterráneos.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/8/8a/La_Canova_Acequia_North.jpg',
+      'https://upload.wikimedia.org/wikipedia/commons/b/b0/OrangeBloss_wb.jpg'
+    ]
+  },
+  barx: {
+    storyTitle: 'Barx, altura, piedra y horizonte',
+    storyOrigin: 'Subida de curvas, montaña abierta y mar al fondo',
+    storyCost: 'Contraste pensado para piezas con ritmo visual y fondo mineral',
+    storyBody:
+      'Barx tiene ese gesto de los lugares a los que se sube para mirar más lejos. El diseño recoge la dureza noble de la piedra, la amplitud del cielo y la línea azul que recuerda que el mar está ahí, aunque quede al fondo. En clave de calcetería artesanal valenciana, el modelo trabaja el contraste con mucha limpieza para ofrecer una pieza firme, vistosa y muy ligada a los paisajes que unen montaña y Mediterráneo.',
+    storyBodyVa:
+      'Barx és altura, pedra i aire obert. El model juga amb grisos minerals i blaus d\'horitzó per a donar-li força i claredat a la indumentària valenciana.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Barx inspirados en la montaña, la piedra y el horizonte mediterráneo. Diseño artesanal con contraste elegante.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/a/ae/Barx_des_del_cim_de_l%27Aldaia%2C_a_la_serra_del_Buixcarr%C3%B3.jpg'
+    ]
+  },
+  'el-nespler': {
+    storyTitle: 'El Nespler, lo dulce de lo cotidiano',
+    storyOrigin: 'Patios mediterráneos, fruta madura y memoria doméstica',
+    storyCost: 'Paleta cálida para un diseño amable y muy reconocible',
+    storyBody:
+      'El Nespler nace de una imagen sencilla y poderosa: la fruta del patio, la sobremesa lenta y las manos manchadas de un verano mediterráneo. El diseño traduce esa ternura doméstica en tonos anaranjados, verdes suaves y matices cálidos que hacen del calcetín una pieza cercana y luminosa. Dentro de la colección de calcetines tradicionales valencianos, es uno de esos modelos que conectan con la parte más íntima y cotidiana del paisaje.',
+    storyBodyVa:
+      'El Nespler parla de pati, d\'estiu i de fruita madura. És un model càlid i amable, amb colors mediterranis que transmeten proximitat i memòria quotidiana.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos El Nespler inspirados en el níspero y los patios mediterráneos. Artesanía cálida y luminosa.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/9/99/Medlar_pomes_and_leaves.jpg'
+    ]
+  },
+  '3-fonts': {
+    storyTitle: '3-Fonts y el paisaje del agua compartida',
+    storyOrigin: 'Fuentes como punto de encuentro en el territorio valenciano',
+    storyCost: 'Diseño de contraste fresco con lectura acuática y mineral',
+    storyBody:
+      'Tres fuentes significan conversación, paso, descanso y memoria de camino. Este modelo toma esa idea del agua compartida para construir una pieza donde mandan los azules limpios, los verdes de musgo y la piedra que encauza el caudal. Son calcetines tradicionales valencianos con una lectura fresca y muy territorial, pensados para quien aprecia los diseños que cuentan paisaje sin perder equilibrio ni elegancia.',
+    storyBodyVa:
+      '3-Fonts naix de l\'aigua, de la pedra i dels llocs on la gent es troba. El model combina blaus clars i verds humits per a una peça fresca i molt vinculada al territori.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos 3-Fonts inspirados en fuentes, agua y piedra. Diseño artesanal fresco para indumentaria valenciana.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/f/f6/Nacentemackinac.jpg'
+    ]
+  },
+  '3-fonts-con-letra': {
+    storyTitle: '3-Fonts con Letra, el paisaje cuando se nombra',
+    storyOrigin: 'La fuente como memoria y la letra como gesto de identidad',
+    storyCost: 'Versión personalizada con una capa simbólica añadida al diseño base',
+    storyBody:
+      '3-Fonts con Letra conserva la frescura del agua, la piedra y el musgo, pero añade algo más: la elegancia de lo nombrado. La letra introduce identidad sin romper el equilibrio del diseño y convierte el calcetín en una pieza todavía más personal. Dentro de la calcetería artesanal valenciana, esta versión funciona muy bien cuando se busca tradición con un matiz propio, reconocible y delicadamente singular.',
+    storyBodyVa:
+      '3-Fonts amb lletra manté l\'essència d\'aigua i pedra del model original, però afegeix identitat. La lletra li dona un punt personal i distingit sense perdre arrel valenciana.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos 3-Fonts con Letra inspirados en fuentes y paisaje de agua. Versión artesanal personalizada con identidad propia.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/f/f6/Nacentemackinac.jpg'
+    ]
+  },
+  acacia: {
+    storyTitle: 'Acacia, sombra y flor sobre el patio',
+    storyOrigin: 'Árbol mediterráneo, verano doméstico y luz tamizada',
+    storyCost: 'Paleta vegetal de blancos, verdes y marrones cálidos',
+    storyBody:
+      'Acacia remite a los veranos de patio, a la sombra buena y a la flor clara que cae sobre el suelo cuando el calor aprieta. El diseño trabaja esa atmósfera con blancos floridos, verdes profundos y un marrón cálido que recuerda la corteza del árbol. Como calcetín tradicional valenciano, es una pieza elegante y fresca, muy adecuada para conjuntos que agradecen un detalle natural y un tono mediterráneo más suave.',
+    storyBodyVa:
+      'Acacia és ombra, flor blanca i pati d\'estiu. El model combina verds profunds i blancs suaus per a una peça natural, fresca i molt mediterrània.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Acacia inspirados en la sombra, la flor y el patio mediterráneo. Diseño artesanal natural y elegante.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/b/bd/Acacia_dealbata_tree_2.jpg'
+    ]
+  },
+  arenal: {
+    storyTitle: 'Arenal, donde la arena toca el Mediterráneo',
+    storyOrigin: 'Orilla, espuma y transición entre tierra y mar',
+    storyCost: 'Diseño luminoso de arena mojada, blanco espumoso y azul abierto',
+    storyBody:
+      'Arenal se inspira en ese punto exacto donde la arena húmeda, la espuma y el cielo se mezclan en una misma franja de luz. El modelo lleva al lenguaje de la calcetería artesanal valenciana colores claros, azules serenos y una sensación de horizonte abierto que funciona muy bien en conjunto. Es una pieza mediterránea y limpia, ideal para quien busca calcetines tradicionales con un aire costero y elegante.',
+    storyBodyVa:
+      'Arenal mira a la vora del mar, a l\'escuma i a l\'arena banyada. El model és clar, mediterrani i molt lluminós, amb una elegància costanera fàcil de reconéixer.',
+    storyMetaDescription:
+      'Calcetines tradicionales valencianos Arenal inspirados en la arena, la espuma y el Mediterráneo. Diseño artesanal luminoso para indumentaria valenciana.',
+    storyImages: [
+      'https://upload.wikimedia.org/wikipedia/commons/4/43/Platja_de_l%27Arenal.jpg',
+      'https://upload.wikimedia.org/wikipedia/commons/9/96/Mediterranee_02_EN.jpg'
+    ]
+  }
+}
+
+for (const [id, payload] of Object.entries(narratives)) {
+  const { data: current, error: fetchError } = await supabase
+    .from('products')
+    .select('metadata')
+    .eq('id', id)
+    .single()
+
+  if (fetchError) {
+    throw fetchError
+  }
+
+  const metadata = {
+    ...(current?.metadata ?? {}),
+    ...payload
+  }
+
+  const { error: updateError } = await supabase
+    .from('products')
+    .update({ metadata })
+    .eq('id', id)
+
+  if (updateError) {
+    throw updateError
+  }
+
+  console.log(`Updated ${id}`)
+}

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   absoluteUrl,
   buildProductBreadcrumbJsonLd,
   buildProductJsonLd,
+  buildProductAltText,
   getPrimaryProductImage
 } from '@/lib/seo'
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs'
@@ -63,7 +64,11 @@ export async function generateMetadata({ params }: ProductPageProps): Promise<Me
           ? [
             {
               url: image,
-              alt: `Calcetines valencianos modelo ${product.name}`
+              alt: buildProductAltText({
+                name: product.name,
+                color: product.color,
+                category: product.category
+              })
             }
           ]
           : undefined

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   buildProductAltText,
   getPrimaryProductImage
 } from '@/lib/seo'
+import { buildProductMetaDescription } from '@/lib/productEditorial'
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs'
 import { getSiteSettings } from '@/lib/settings'
 
@@ -34,17 +35,7 @@ export async function generateMetadata({ params }: ProductPageProps): Promise<Me
     // SEO: Título específico para producto
     const title = `${product.name} | Calcetines Tradicionales`
 
-    // SEO: Descripción enriquecida para evitar "thin content" / duplicidad
-    // SEO: Descripción enriquecida. Si la de base de datos es muy corta (<60 chars) o inexistente, generamos una completa.
-    let description = product.description || ''
-
-    const isThinContent = description.length < 60
-
-    if (isThinContent) {
-      description = `Calcetines tradicionales valencianos modelo ${product.name}. Reproducción artesanal${product.color ? ` en color ${product.color}` : ''}. Perfectos para indumentaria tradicional y bailes regionales. Confección en Alcoi de alta calidad.`
-    }
-
-    description = description.slice(0, 160)
+    const description = buildProductMetaDescription(product)
 
     const url = absoluteUrl(`/${product.id}`)
     const image = getPrimaryProductImage(product)

--- a/src/app/api/admin/sales/list/route.ts
+++ b/src/app/api/admin/sales/list/route.ts
@@ -32,11 +32,21 @@ export async function GET() {
     // Sort by position to get the main image (usually position 0 or 1)
     assets.sort((a: any, b: any) => (a.position || 0) - (b.position || 0))
     const image = assets.length > 0 ? assets[0].url : null
+    const catalogPrice = sale.products?.price ?? null
+    const storedPrice = sale.product_price ?? null
+    const resolvedPrice =
+      storedPrice ??
+      (catalogPrice !== null
+        ? sale.is_wholesale
+          ? catalogPrice * 0.5
+          : catalogPrice
+        : null)
 
     return {
       ...sale,
       product_image: image,
-      product_price: sale.products?.price || null
+      catalog_price: catalogPrice,
+      product_price: resolvedPrice
     }
   })
 

--- a/src/app/ca/blog/[slug]/page.tsx
+++ b/src/app/ca/blog/[slug]/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { getAllPosts, getPostBySlug } from '@/lib/blog'
+import { renderMarkdown } from '@/lib/markdown'
+import {
+  absoluteUrl,
+  buildArticleJsonLd,
+  defaultOpenGraphImage,
+  siteMetadata
+} from '@/lib/seo'
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs'
+
+type BlogPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export const generateStaticParams = async () => {
+  const posts = await getAllPosts('ca')
+  return posts.map(post => ({ slug: post.slug }))
+}
+
+export const generateMetadata = async ({ params }: BlogPageProps): Promise<Metadata> => {
+  const { slug } = await params
+  const post = await getPostBySlug(slug, 'ca')
+  if (!post) {
+    return {
+      title: 'Article no trobat · La Tortugueta'
+    }
+  }
+
+  const url = absoluteUrl(`/ca/blog/${post.slug}`)
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    alternates: {
+      canonical: url,
+      languages: {
+        es: `/blog/${post.slug}`,
+        ca: `/ca/blog/${post.slug}`,
+        en: `/en/blog/${post.slug}`
+      }
+    },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt || siteMetadata.description,
+      url,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+      siteName: siteMetadata.name,
+      images: [
+        {
+          url: post.image ? absoluteUrl(post.image) : defaultOpenGraphImage,
+          width: 1200,
+          height: 630,
+          alt: post.title
+        }
+      ]
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt || siteMetadata.description,
+      images: [post.image ? absoluteUrl(post.image) : defaultOpenGraphImage]
+    }
+  }
+}
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat('ca-ES', { dateStyle: 'long' }).format(new Date(value))
+
+export default async function BlogPostPageCa({ params }: BlogPageProps) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug, 'ca')
+
+  if (!post) {
+    notFound()
+  }
+
+  const html = renderMarkdown(post.content)
+  const articleJsonLd = buildArticleJsonLd(post)
+  const breadcrumbs = [
+    { label: 'Inici', href: '/ca' },
+    { label: 'Blog', href: '/ca/blog' },
+    { label: post.title, current: true }
+  ]
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+      <Breadcrumbs items={breadcrumbs} />
+      <article className="bg-white text-neutral-900">
+        <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-16 sm:px-6 lg:px-8">
+          <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">
+            {formatDate(post.date)}
+          </p>
+          <h1 className="text-4xl font-semibold text-neutral-900">{post.title}</h1>
+          <p className="text-sm uppercase tracking-[0.25em] text-neutral-500">
+            Per {post.author}
+          </p>
+          <div
+            className="article-content"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-t border-neutral-200 pt-6 text-xs uppercase tracking-[0.3em] text-neutral-500">
+            <Link href="/ca/blog" className="hover:text-neutral-900">
+              ← Tornar al blog
+            </Link>
+            <div className="flex flex-wrap gap-3">
+              {post.tags.map(tag => (
+                <span key={tag} className="rounded-full border border-neutral-200 px-3 py-1">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </article>
+    </>
+  )
+}

--- a/src/app/ca/blog/page.tsx
+++ b/src/app/ca/blog/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
 
 export default async function BlogIndexPageCa() {
     const posts = await getAllPosts('ca')
-    const blogJsonLd = buildBlogListingJsonLd(posts)
+    const blogJsonLd = buildBlogListingJsonLd(posts, 'ca')
 
     return (
         <>

--- a/src/app/ca/calcetines-tradicionales/page.tsx
+++ b/src/app/ca/calcetines-tradicionales/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { ProductImage } from '@/components/common/ProductImage'
+import { getAllProducts } from '@/lib/products'
+import {
+  absoluteUrl,
+  buildBreadcrumbJsonLd,
+  buildFaqPageJsonLd,
+  buildProductAltText,
+  siteMetadata
+} from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Calcetins Tradicionals Valencians Fets a Mà',
+  description:
+    'Descobreix els nostres calcetins tradicionals valencians, fets a mà amb tècniques artesanals. Dissenys únics, materials naturals i encàrrecs personalitzats.',
+  alternates: {
+    canonical: absoluteUrl('/ca/calcetines-tradicionales'),
+    languages: {
+      es: '/calcetines-tradicionales',
+      ca: '/ca/calcetines-tradicionales',
+      en: '/en/calcetines-tradicionales'
+    }
+  },
+  openGraph: {
+    title: 'Calcetins Tradicionals Valencians | La Tortugueta',
+    description:
+      'Pàgina pilar sobre calcetins tradicionals valencians, models artesanals, procés de confecció i encàrrecs personalitzats.',
+    url: absoluteUrl('/ca/calcetines-tradicionales'),
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Calcetins Tradicionals Valencians | La Tortugueta',
+    description:
+      'Guia completa sobre calcetins tradicionals valencians, models artesanals i la col·lecció actual.'
+  }
+}
+
+const faqEntries = [
+  {
+    question: 'Què són els calcetins tradicionals valencians?',
+    answer:
+      'Són calcetins inspirats en models històrics de la indumentària valenciana, teixits amb fils de qualitat i acabats artesanals per a roba tradicional, danses i recreació històrica.'
+  },
+  {
+    question: 'En què es diferencien dels calcetins industrials?',
+    answer:
+      'La diferència principal està en la cura del disseny, la selecció del fil, la personalització per talla i color, i el treball artesanal pensat per respectar l’estètica tradicional.'
+  },
+  {
+    question: 'Quina talla he de triar?',
+    answer:
+      'Treballem sobre la talla real del peu i podem ajustar alçada de canya o amplària si cal. Si tens dubtes, el millor és escriure’ns abans de produir.'
+  },
+  {
+    question: 'Es poden personalitzar colors o dibuixos?',
+    answer:
+      'Sí. La Tortugueta treballa per encàrrec i pot adaptar colors, combinacions i referències històriques perquè el calcetí encaixe amb la teua indumentària o amb un model antic.'
+  }
+]
+
+export default async function TraditionalSocksPageCa() {
+  const products = await getAllProducts()
+  const featuredProducts = products
+    .filter(product => product.price > 0 && product.image)
+    .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
+    .slice(0, 6)
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: 'Inici', url: '/ca' },
+    { name: 'Calcetins Tradicionals', url: '/ca/calcetines-tradicionales' }
+  ])
+  const faqJsonLd = buildFaqPageJsonLd(faqEntries)
+
+  return (
+    <div className="bg-white text-neutral-900">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbJsonLd, faqJsonLd]) }}
+      />
+
+      <section className="border-b border-neutral-200 bg-gradient-to-b from-stone-50 via-white to-white">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="max-w-4xl space-y-6">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Guia principal</p>
+            <h1 className="text-4xl font-semibold text-neutral-900 sm:text-5xl">
+              Calcetins Tradicionals Valencians
+            </h1>
+            <p className="text-lg leading-relaxed text-neutral-700">
+              A La Tortugueta entenem els calcetins tradicionals com una peça essencial de la indumentària, no com
+              un accessori secundari. Per això documentem models antics, estudiem materials i reproduïm cada disseny
+              amb una mirada artesanal que uneix memòria tèxtil i ús actual.
+            </p>
+            <p className="max-w-3xl text-sm leading-relaxed text-neutral-600">
+              Aquesta pàgina reuneix la base de la nostra col·lecció, el procés de treball i les respostes que més
+              busquen les persones que cerquen calcetins tradicionals valencians per a roba tradicional, danses o
+              recreació històrica.
+            </p>
+            <div className="flex flex-wrap gap-4 pt-2 text-xs uppercase tracking-[0.3em]">
+              <Link href="/#catalogo" className="rounded-full bg-neutral-900 px-6 py-3 text-white">
+                Veure col·lecció
+              </Link>
+              <Link href="/contacto" className="rounded-full border border-neutral-900 px-6 py-3 text-neutral-900">
+                Demanar assessorament
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+          <div className="space-y-6 text-sm leading-relaxed text-neutral-700">
+            <h2 className="text-3xl font-semibold text-neutral-900">Una tradició tèxtil ben viva</h2>
+            <p>
+              Els calcetins tradicionals valencians formen part del llenguatge visual de la indumentària popular.
+              Parlen d’ofici, de territori i d’una manera de vestir on cada detall té intenció.
+            </p>
+            <p>
+              El nostre treball parteix de l’arxiu i de l’observació. Revisem models antics, estudiem referències
+              conservades en col·leccions particulars i traslladem eixa informació a peces que es puguen vestir hui
+              amb comoditat.
+            </p>
+            <p>
+              Si busques <strong>calcetins tradicionals valencians</strong>, ací trobaràs una col·lecció viva:
+              materials de qualitat, confecció cuidada i atenció directa abans d’acceptar l’encàrrec.
+            </p>
+            <p>
+              També treballem la personalització. Moltes persones arriben amb una foto antiga, una referència familiar
+              o una combinació cromàtica molt concreta. En eixos casos, el catàleg és el punt de partida, no el límit.
+              Pots consultar la <Link href="/colores" className="underline underline-offset-4">carta de colors</Link>,
+              revisar el <Link href="/ca/blog" className="underline underline-offset-4">blog</Link> i escriure’ns per adaptar la peça.
+            </p>
+          </div>
+
+          <aside className="space-y-4 rounded-3xl border border-neutral-200 bg-stone-50 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Per què triar-los</p>
+            <h3 className="text-2xl font-semibold text-neutral-900">Què cuidem en cada parell</h3>
+            <ul className="space-y-3 text-sm leading-relaxed text-neutral-700">
+              <li>Documentació de models històrics i reinterpretació amb criteri.</li>
+              <li>Selecció de fils i colors pensats per a l’ús i la durabilitat.</li>
+              <li>Treball per encàrrec adaptat a talla, alçada de canya i combinacions cromàtiques.</li>
+              <li>Atenció directa per resoldre dubtes abans de confirmar l’encàrrec.</li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="border-y border-neutral-200 bg-neutral-50">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Col·lecció destacada</p>
+              <h2 className="text-3xl font-semibold text-neutral-900">Models artesanals de la col·lecció</h2>
+            </div>
+            <Link href="/#catalogo" className="text-xs uppercase tracking-[0.3em] text-neutral-600 underline underline-offset-4">
+              Veure col·lecció completa
+            </Link>
+          </div>
+
+          <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {featuredProducts.map((product, index) => (
+              <Link
+                key={product.id}
+                href={`/${product.id}`}
+                className="group space-y-4 rounded-3xl border border-neutral-200 bg-white p-5 transition hover:border-neutral-900"
+              >
+                <div className="relative aspect-[3/4] overflow-hidden rounded-2xl bg-white">
+                  <ProductImage
+                    imagePath={product.image}
+                    variant="thumb"
+                    alt={buildProductAltText({
+                      name: product.name,
+                      color: product.color,
+                      category: product.category,
+                      viewIndex: index
+                    })}
+                    fill
+                    className="object-contain transition-transform duration-500 group-hover:scale-[1.03]"
+                    sizes="(min-width: 1024px) 28vw, (min-width: 640px) 45vw, 90vw"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">
+                    {product.category ?? 'Col·lecció artesanal'}
+                  </p>
+                  <h3 className="text-lg font-semibold text-neutral-900">{product.name}</h3>
+                  <p className="text-sm text-neutral-600">{product.price.toFixed(2)} €</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">FAQ</p>
+            <h2 className="text-3xl font-semibold text-neutral-900">Preguntes freqüents</h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {faqEntries.map(entry => (
+              <article key={entry.question} className="rounded-3xl border border-neutral-200 p-6">
+                <h3 className="text-lg font-semibold text-neutral-900">{entry.question}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-neutral-700">{entry.answer}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-neutral-900 text-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 text-center sm:px-6 lg:px-8">
+          <p className="text-xs uppercase tracking-[0.35em] text-white/60">{siteMetadata.shortDescription}</p>
+          <h2 className="mt-4 text-3xl font-semibold">Troba el teu pròxim parell</h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-4 text-xs uppercase tracking-[0.3em]">
+            <Link href="/#catalogo" className="rounded-full bg-white px-6 py-3 text-neutral-900">
+              Veure col·lecció
+            </Link>
+            <Link href="/contacto" className="rounded-full border border-white/40 px-6 py-3 text-white">
+              Contactar amb La Tortugueta
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/ca/colores/page.tsx
+++ b/src/app/ca/colores/page.tsx
@@ -1,11 +1,27 @@
 import React from 'react';
+import Link from 'next/link';
 import { YARN_COLORS } from '@/lib/colors/constants';
 import { ColorCatalogGrid } from '@/components/catalog/ColorCatalogGrid';
 import { Metadata } from 'next';
+import { absoluteUrl, siteMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
-    title: 'Carta de Colors | La Tortugueta',
-    description: 'Explora la nostra carta de colors completa. Troba el to perfecte per als teus mitjons personalitzats.',
+    title: 'Carta de Colors | Calcetins Tradicionals Valencians',
+    description: 'Explora la carta de colors de La Tortugueta per triar tons i combinacions per a calcetins tradicionals valencians i encàrrecs personalitzats.',
+    alternates: {
+        canonical: absoluteUrl('/ca/colores'),
+        languages: {
+            es: '/colores',
+            en: '/en/colores',
+            ca: '/ca/colores'
+        }
+    },
+    openGraph: {
+        title: `${siteMetadata.name} · Carta de colors`,
+        description: 'Consulta la carta de colors de La Tortugueta i tria el to adequat per als teus calcetins tradicionals valencians personalitzats.',
+        url: absoluteUrl('/ca/colores'),
+        type: 'website'
+    }
 };
 
 export default function ColorCatalogPage() {
@@ -25,6 +41,17 @@ export default function ColorCatalogPage() {
                             </p>
                             <p>
                                 I saps què és el millor? Com absorbeix el tint. Els colors queden vius, intensos, i aguanten rentat rere rentat sense perdre aquesta alegria i sense fer aquestes boletes molestes que tant enlletgeixen. El portem de molt lluny, sí, però el tintem i el teixim aquí, a la nostra terra, en tallers de confiança de tota la vida. Perquè per fer les coses bé, cal barrejar el millor de fora amb el mestratge de casa.
+                            </p>
+                        </div>
+
+                        <div className="rounded-3xl border border-gray-200 bg-white px-6 py-5 text-left max-w-3xl mx-auto">
+                            <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Guia recomanada</p>
+                            <p className="mt-2 text-base text-gray-800">
+                                Abans de triar combinacions, visita la nostra pàgina sobre{' '}
+                                <Link href="/ca/calcetines-tradicionales" className="underline underline-offset-4">
+                                    calcetins tradicionals valencians
+                                </Link>{' '}
+                                per entendre millor estils, materials i com encaixa cada model dins de la indumentària.
                             </p>
                         </div>
 

--- a/src/app/ca/quienes-somos/page.tsx
+++ b/src/app/ca/quienes-somos/page.tsx
@@ -7,8 +7,8 @@ import { dictionaries } from '@/i18n/dictionaries'
 export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
-    title: dictionaries.ca.about.metaTitle,
-    description: dictionaries.ca.about.metaDescription,
+    title: 'Qui Som | Taller Artesà de Calcetins Tradicionals',
+    description: 'Coneix La Tortugueta, taller artesà de calcetins tradicionals valencians des de 1989. Història, ofici familiar i encàrrecs personalitzats des d’Alcoi.',
     alternates: {
         canonical: absoluteUrl('/ca/quienes-somos'),
         languages: {
@@ -18,10 +18,15 @@ export const metadata: Metadata = {
         }
     },
     openGraph: {
-        title: `${siteMetadata.name} · ${dictionaries.ca.about.metaTitle}`,
-        description: dictionaries.ca.about.metaDescription,
+        title: `${siteMetadata.name} · Qui som`,
+        description: 'Descobreix la història de La Tortugueta, un taller familiar especialitzat en calcetins tradicionals valencians, referències històriques i treball per encàrrec.',
         url: absoluteUrl('/ca/quienes-somos'),
         type: 'website'
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: `${siteMetadata.name} · Qui som`,
+        description: 'Taller familiar de calcetins tradicionals valencians des de 1989, amb ofici artesà i producció personalitzada.'
     }
 }
 

--- a/src/app/calcetines-tradicionales/page.tsx
+++ b/src/app/calcetines-tradicionales/page.tsx
@@ -16,7 +16,12 @@ export const metadata: Metadata = {
   description:
     'Descubre nuestros calcetines tradicionales valencianos, hechos a mano con técnicas artesanales. Diseños únicos, materiales naturales y encargos personalizados.',
   alternates: {
-    canonical: absoluteUrl('/calcetines-tradicionales')
+    canonical: absoluteUrl('/calcetines-tradicionales'),
+    languages: {
+      es: '/calcetines-tradicionales',
+      ca: '/ca/calcetines-tradicionales',
+      en: '/en/calcetines-tradicionales'
+    }
   },
   openGraph: {
     title: 'Calcetines Tradicionales Valencianos | La Tortugueta',

--- a/src/app/calcetines-tradicionales/page.tsx
+++ b/src/app/calcetines-tradicionales/page.tsx
@@ -1,0 +1,335 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { ProductImage } from '@/components/common/ProductImage'
+import { getAllProducts } from '@/lib/products'
+import {
+  absoluteUrl,
+  buildBreadcrumbJsonLd,
+  buildFaqPageJsonLd,
+  buildProductAltText,
+  siteMetadata
+} from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Calcetines Tradicionales Valencianos Hechos a Mano',
+  description:
+    'Descubre nuestros calcetines tradicionales valencianos, hechos a mano con técnicas artesanales. Diseños únicos, materiales naturales y encargos personalizados.',
+  alternates: {
+    canonical: absoluteUrl('/calcetines-tradicionales')
+  },
+  openGraph: {
+    title: 'Calcetines Tradicionales Valencianos | La Tortugueta',
+    description:
+      'Página pilar de La Tortugueta sobre calcetines tradicionales valencianos, colección artesanal, proceso de confección y encargos personalizados.',
+    url: absoluteUrl('/calcetines-tradicionales'),
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Calcetines Tradicionales Valencianos | La Tortugueta',
+    description:
+      'Guía completa sobre calcetines tradicionales valencianos, modelos artesanales y colección disponible.'
+  }
+}
+
+const faqEntries = [
+  {
+    question: '¿Qué son los calcetines tradicionales valencianos?',
+    answer:
+      'Son calcetines inspirados en modelos históricos de la indumentaria valenciana, tejidos con materiales de calidad y acabados artesanales para fallas, danses y vestimenta tradicional.'
+  },
+  {
+    question: '¿En qué se diferencian de los calcetines industriales?',
+    answer:
+      'La principal diferencia está en el cuidado del diseño, la selección del hilo, la personalización por talla y color, y el trabajo artesanal pensado para respetar la estética tradicional.'
+  },
+  {
+    question: '¿Qué talla debo elegir?',
+    answer:
+      'Trabajamos sobre la talla real del pie y podemos ajustar altura de caña o ancho si el encargo lo necesita. Si dudas, lo mejor es escribirnos y te orientamos antes de producir.'
+  },
+  {
+    question: '¿Se pueden personalizar colores o dibujos?',
+    answer:
+      'Sí. La Tortugueta trabaja bajo pedido y puede adaptar colores, combinaciones y referencias históricas para que el calcetín encaje con tu indumentaria o con un diseño antiguo.'
+  }
+]
+
+export default async function TraditionalSocksPage() {
+  const products = await getAllProducts()
+  const featuredProducts = products
+    .filter(product => product.price > 0 && product.image)
+    .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
+    .slice(0, 6)
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: 'Inicio', url: '/' },
+    { name: 'Calcetines Tradicionales', url: '/calcetines-tradicionales' }
+  ])
+  const faqJsonLd = buildFaqPageJsonLd(faqEntries)
+
+  return (
+    <div className="bg-white text-neutral-900">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbJsonLd, faqJsonLd]) }}
+      />
+
+      <section className="border-b border-neutral-200 bg-gradient-to-b from-stone-50 via-white to-white">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="max-w-4xl space-y-6">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Guía principal</p>
+            <h1 className="text-4xl font-semibold text-neutral-900 sm:text-5xl">
+              Calcetines Tradicionales Valencianos
+            </h1>
+            <p className="text-lg leading-relaxed text-neutral-700">
+              En La Tortugueta entendemos los calcetines tradicionales como una pieza esencial de la indumentaria,
+              no como un accesorio secundario. Por eso documentamos modelos antiguos, estudiamos materiales y
+              reproducimos cada diseño con una mirada artesanal que une memoria textil y uso actual.
+            </p>
+            <p className="max-w-3xl text-sm leading-relaxed text-neutral-600">
+              Esta página reúne la base de nuestra colección, el proceso de trabajo y las respuestas que más nos
+              hacen quienes buscan calcetines tradicionales valencianos para fallera, fallero, grupos de danses o
+              recreación histórica.
+            </p>
+            <div className="flex flex-wrap gap-4 pt-2 text-xs uppercase tracking-[0.3em]">
+              <Link href="/#catalogo" className="rounded-full bg-neutral-900 px-6 py-3 text-white">
+                Ver colección
+              </Link>
+              <Link href="/contacto" className="rounded-full border border-neutral-900 px-6 py-3 text-neutral-900">
+                Pedir asesoramiento
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+          <div className="space-y-6 text-sm leading-relaxed text-neutral-700">
+            <h2 className="text-3xl font-semibold text-neutral-900">
+              Una tradición textil que sigue viva
+            </h2>
+            <p>
+              Los calcetines tradicionales valencianos forman parte del conjunto visual que da identidad a la
+              indumentaria popular. Hablan de oficio, de territorio y de una manera de vestir donde cada detalle
+              tiene intención. El dibujo, la caña, el color o la textura cambian la presencia del conjunto y por
+              eso conviene tratarlos con el mismo respeto que un jubón, una falda o un delantal.
+            </p>
+            <p>
+              Nuestro trabajo parte del archivo y de la observación. Revisamos modelos antiguos, estudiamos
+              referencias conservadas en colecciones particulares y trasladamos esa información a piezas que puedan
+              usarse hoy con comodidad. No buscamos una copia vacía: buscamos una reproducción fiel, útil y bien
+              resuelta para quien quiere vestir tradición con rigor.
+            </p>
+            <p>
+              Si vienes buscando <strong>calcetines tradicionales valencianos</strong>, aquí encontrarás una
+              colección viva. Algunos diseños son sobrios y otros más ornamentales; unos están pensados para uso
+              frecuente y otros para completar conjuntos muy concretos. Todos comparten la misma lógica: buena
+              materia prima, confección cuidada y una atención personal antes de aceptar el encargo.
+            </p>
+            <p>
+              También trabajamos la personalización. Muchas personas llegan con una referencia familiar, una foto
+              antigua o una idea concreta de combinación cromática. En esos casos, el catálogo es el punto de
+              partida, no el límite. Puedes ver nuestra <Link href="/colores" className="underline underline-offset-4">carta de colores</Link>,
+              estudiar modelos del <Link href="/blog" className="underline underline-offset-4">blog</Link> y escribirnos para
+              adaptar la pieza.
+            </p>
+          </div>
+
+          <aside className="space-y-4 rounded-3xl border border-neutral-200 bg-stone-50 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Por qué elegirlos</p>
+            <h3 className="text-2xl font-semibold text-neutral-900">Qué cuidamos en cada par</h3>
+            <ul className="space-y-3 text-sm leading-relaxed text-neutral-700">
+              <li>Documentación de modelos históricos y reinterpretación con criterio.</li>
+              <li>Selección de hilos y colores pensados para aguantar el uso y el lavado.</li>
+              <li>Trabajo bajo pedido para ajustar talla, altura de caña y combinación cromática.</li>
+              <li>Atención directa para resolver dudas antes de confirmar el encargo.</li>
+            </ul>
+            <p className="text-sm text-neutral-600">
+              Si quieres comparar diseños concretos, visita el <Link href="/#catalogo" className="underline underline-offset-4">catálogo completo</Link> o
+              explora nuestra selección destacada más abajo.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section className="border-y border-neutral-200 bg-neutral-50">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Colección destacada</p>
+              <h2 className="text-3xl font-semibold text-neutral-900">Modelos artesanales de la colección</h2>
+              <p className="max-w-3xl text-sm leading-relaxed text-neutral-600">
+                Una selección de modelos disponibles para usar como referencia de estilo, color y precio antes de
+                hacer tu pedido.
+              </p>
+            </div>
+            <Link href="/#catalogo" className="text-xs uppercase tracking-[0.3em] text-neutral-600 underline underline-offset-4">
+              Ver colección completa
+            </Link>
+          </div>
+
+          <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {featuredProducts.map((product, index) => (
+              <Link
+                key={product.id}
+                href={`/${product.id}`}
+                className="group space-y-4 rounded-3xl border border-neutral-200 bg-white p-5 transition hover:border-neutral-900"
+              >
+                <div className="relative aspect-[3/4] overflow-hidden rounded-2xl bg-white">
+                  <ProductImage
+                    imagePath={product.image}
+                    variant="thumb"
+                    alt={buildProductAltText({
+                      name: product.name,
+                      color: product.color,
+                      category: product.category,
+                      viewIndex: index
+                    })}
+                    fill
+                    className="object-contain transition-transform duration-500 group-hover:scale-[1.03]"
+                    sizes="(min-width: 1024px) 28vw, (min-width: 640px) 45vw, 90vw"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">
+                    {product.category ?? 'Colección artesanal'}
+                  </p>
+                  <h3 className="text-lg font-semibold text-neutral-900">{product.name}</h3>
+                  <p className="text-sm text-neutral-600">
+                    {product.price.toFixed(2)} €
+                    <span className="ml-1 text-xs uppercase tracking-[0.2em] text-neutral-400">+ envío</span>
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-3">
+          <div className="space-y-3 rounded-3xl border border-neutral-200 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Paso 1</p>
+            <h2 className="text-2xl font-semibold text-neutral-900">Elegimos la referencia</h2>
+            <p className="text-sm leading-relaxed text-neutral-700">
+              Partimos del catálogo, de una fotografía antigua o de una necesidad concreta de indumentaria para
+              definir la base del diseño.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-3xl border border-neutral-200 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Paso 2</p>
+            <h2 className="text-2xl font-semibold text-neutral-900">Ajustamos color y talla</h2>
+            <p className="text-sm leading-relaxed text-neutral-700">
+              Revisamos talla, gama cromática y cualquier particularidad del encargo para que el resultado encaje
+              visualmente y también en el uso real.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-3xl border border-neutral-200 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Paso 3</p>
+            <h2 className="text-2xl font-semibold text-neutral-900">Confeccionamos bajo pedido</h2>
+            <p className="text-sm leading-relaxed text-neutral-700">
+              La producción se hace con criterio artesanal, priorizando acabados, consistencia del tejido y una
+              entrega alineada con el tipo de pieza solicitada.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-10 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+          <div className="space-y-5 text-sm leading-relaxed text-neutral-700">
+            <h2 className="text-3xl font-semibold text-neutral-900">Cómo elegir un buen modelo</h2>
+            <p>
+              Un buen calcetín tradicional no depende solo del dibujo. Conviene mirar el tipo de acto donde se va a
+              usar, la combinación con el resto de la indumentaria, la estación del año y la frecuencia de uso.
+              Para una persona que participa de manera habitual en fallas o danses, la durabilidad del hilo y el
+              equilibrio del color son tan importantes como la fidelidad histórica.
+            </p>
+            <p>
+              Por eso recomendamos empezar por tres preguntas: qué conjunto quieres completar, qué referencias
+              visuales tienes y si buscas una pieza sobria o una pieza con más carácter. A partir de ahí es mucho
+              más fácil decidir entre modelos lisos, rayados o con mayor presencia ornamental. Si necesitas más
+              contexto, en el blog encontrarás la guía sobre{' '}
+              <Link
+                href="/blog/como-elegir-calcetines-tradicionales-calidad"
+                className="underline underline-offset-4"
+              >
+                cómo elegir calcetines tradicionales de calidad
+              </Link>{' '}
+              y un recorrido por la{' '}
+              <Link
+                href="/blog/historia-calcetines-tradicionales-valencianos"
+                className="underline underline-offset-4"
+              >
+                historia de los calcetines tradicionales valencianos
+              </Link>.
+            </p>
+          </div>
+
+          <div className="space-y-4 rounded-3xl border border-neutral-200 bg-stone-50 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Recursos relacionados</p>
+            <ul className="space-y-3 text-sm leading-relaxed text-neutral-700">
+              <li>
+                <Link href="/colores" className="underline underline-offset-4">
+                  Carta de colores
+                </Link>{' '}
+                para preparar combinaciones antes del encargo.
+              </li>
+              <li>
+                <Link href="/quienes-somos" className="underline underline-offset-4">
+                  Quiénes somos
+                </Link>{' '}
+                para conocer el taller y la trayectoria de La Tortugueta.
+              </li>
+              <li>
+                <Link href="/contacto" className="underline underline-offset-4">
+                  Contacto
+                </Link>{' '}
+                si quieres pedir una recomendación o resolver dudas de talla y diseño.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">FAQ</p>
+            <h2 className="text-3xl font-semibold text-neutral-900">Preguntas frecuentes</h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {faqEntries.map(entry => (
+              <article key={entry.question} className="rounded-3xl border border-neutral-200 p-6">
+                <h3 className="text-lg font-semibold text-neutral-900">{entry.question}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-neutral-700">{entry.answer}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-neutral-900 text-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 text-center sm:px-6 lg:px-8">
+          <p className="text-xs uppercase tracking-[0.35em] text-white/60">{siteMetadata.shortDescription}</p>
+          <h2 className="mt-4 text-3xl font-semibold">Encuentra tu próximo par</h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-white/75">
+            Si estás buscando calcetines tradicionales valencianos hechos con criterio artesanal, aquí tienes el
+            mejor punto de partida: catálogo, color, contexto histórico y atención directa en un mismo lugar.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4 text-xs uppercase tracking-[0.3em]">
+            <Link href="/#catalogo" className="rounded-full bg-white px-6 py-3 text-neutral-900">
+              Ver colección
+            </Link>
+            <Link href="/contacto" className="rounded-full border border-white/40 px-6 py-3 text-white">
+              Hablar con La Tortugueta
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/colores/page.tsx
+++ b/src/app/colores/page.tsx
@@ -3,13 +3,29 @@ import Link from 'next/link';
 import { YARN_COLORS } from '@/lib/colors/constants';
 import { ColorBrowser } from '@/components/catalog/ColorBrowser';
 import { Metadata } from 'next';
-import { absoluteUrl, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { absoluteUrl, buildBreadcrumbJsonLd, siteMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
-    title: 'Catálogo de Colores | La Tortugueta',
-    description: 'Explora nuestra carta de colores completa. Encuentra el tono perfecto para tus calcetines personalizados.',
+    title: 'Carta de Colores | Calcetines Tradicionales Valencianos',
+    description: 'Explora la carta de colores de La Tortugueta para elegir combinaciones de calcetines tradicionales valencianos, tonos personalizados y referencias textiles.',
     alternates: {
-        canonical: absoluteUrl('/colores')
+        canonical: absoluteUrl('/colores'),
+        languages: {
+            es: '/colores',
+            en: '/en/colores',
+            ca: '/ca/colores'
+        }
+    },
+    openGraph: {
+        title: `${siteMetadata.name} · Carta de colores`,
+        description: 'Consulta la carta de colores de La Tortugueta y encuentra el tono ideal para tus calcetines tradicionales valencianos personalizados.',
+        url: absoluteUrl('/colores'),
+        type: 'website'
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: `${siteMetadata.name} · Carta de colores`,
+        description: 'Carta de colores para calcetines tradicionales valencianos: tonos, combinaciones y guía para elegir mejor.'
     }
 };
 
@@ -52,6 +68,9 @@ export default function ColorCatalogPage() {
                                     calcetines tradicionales valencianos
                                 </Link>{' '}
                                 para entender mejor estilos, materiales y cómo encaja cada modelo en la indumentaria.
+                            </p>
+                            <p className="mt-2 text-sm text-gray-600">
+                                Si vienes desde Google buscando colores para fallera, danses o encargos personalizados, aquí tienes el punto de partida más útil antes de cerrar tu combinación.
                             </p>
                         </div>
 

--- a/src/app/colores/page.tsx
+++ b/src/app/colores/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { YARN_COLORS } from '@/lib/colors/constants';
 import { ColorBrowser } from '@/components/catalog/ColorBrowser';
 import { Metadata } from 'next';
@@ -40,6 +41,17 @@ export default function ColorCatalogPage() {
                             </p>
                             <p>
                                 ¿Y sabes qué es lo mejor? Cómo absorbe el tinte. Los colores quedan vivos, intensos, y aguantan lavado tras lavado sin perder esa alegría y sin hacer esas bolitas molestas que tanto afean. Lo traemos de muy lejos, sí, pero lo tintamos y lo tejemos aquí, en nuestra tierra, en talleres de confianza de toda la vida. Porque para hacer las cosas bien, hay que mezclar lo mejor de fuera con la maestría de casa.
+                            </p>
+                        </div>
+
+                        <div className="rounded-3xl border border-gray-200 bg-white px-6 py-5 text-left max-w-3xl mx-auto">
+                            <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Guía recomendada</p>
+                            <p className="mt-2 text-base text-gray-800">
+                                Antes de elegir combinaciones, puedes leer nuestra página sobre{' '}
+                                <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                                    calcetines tradicionales valencianos
+                                </Link>{' '}
+                                para entender mejor estilos, materiales y cómo encaja cada modelo en la indumentaria.
                             </p>
                         </div>
 

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -1,18 +1,18 @@
 import Link from 'next/link'
 import { Metadata } from 'next'
-import { CONTACT_NAME, INSTAGRAM_URL, WHATSAPP_LINK } from '@/lib/contact'
+import { INSTAGRAM_URL, WHATSAPP_LINK } from '@/lib/contact'
 import { absoluteUrl, siteMetadata, buildBreadcrumbJsonLd } from '@/lib/seo'
 import { ContactQuickForm } from '@/components/contact/ContactQuickForm'
 
 export const metadata: Metadata = {
   title: 'Contacto',
-  description: 'Escríbenos o ven al taller. Horarios, dirección y datos para encargos personalizados.',
+  description: 'Escríbenos por WhatsApp o correo. Datos de contacto para encargos personalizados.',
   alternates: {
     canonical: absoluteUrl('/contacto')
   },
   openGraph: {
     title: `${siteMetadata.name} · Contacto`,
-    description: 'Escríbenos o ven al taller para encargos de calcetines tradicionales.',
+    description: 'Escríbenos para encargos de calcetines tradicionales.',
     url: absoluteUrl('/contacto'),
     type: 'website'
   }
@@ -37,7 +37,7 @@ export default function ContactPage() {
           <h1 className="text-4xl font-semibold text-neutral-900">Hablemos de tu par de calcetines</h1>
           <p className="text-sm leading-relaxed text-neutral-600">
             En La Tortugueta respondemos personalmente a cada encargo. Cuéntanos la historia que quieres reproducir,
-            envíanos fotos o visita el taller de Alcoi. También puedes escribirnos a través de WhatsApp o correo electrónico.
+            envíanos fotos. También puedes escribirnos a través de WhatsApp o correo electrónico.
           </p>
         </div>
       </section>
@@ -63,11 +63,6 @@ export default function ContactPage() {
               </p>
             </li>
             <li>
-              <strong className="text-xs uppercase tracking-[0.3em] text-neutral-500">Dirección</strong>
-              <p className="mt-1 text-base text-neutral-900">C/ San Nicolás 12, 03801 Alcoy (Alicante)</p>
-              <p className="text-xs text-neutral-400">Visitas con cita previa.</p>
-            </li>
-            <li>
               <strong className="text-xs uppercase tracking-[0.3em] text-neutral-500">RRSS</strong>
               <p className="mt-1 text-base text-neutral-900">
                 <a href={INSTAGRAM_URL} className="underline">
@@ -88,19 +83,7 @@ export default function ContactPage() {
         </div>
 
         <div className="space-y-6 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
-          <h2 className="text-xl font-semibold text-neutral-900">Mapa y formulario rápido</h2>
-          <div className="mt-12 h-64 w-full overflow-hidden rounded-3xl grayscale filter">
-            {/* Map removed or updated to generic Alcoy view if preferred, or kept as is but pointing to Alcoy general */}
-            <iframe
-              title="Ubicación"
-              width="100%"
-              height="100%"
-              style={{ border: 0 }}
-              loading="lazy"
-              allowFullScreen
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d12715.8454108726833!2d-0.48!3d38.70!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd6234ef2899ca11%3A0x28ed5c828a7ea50!2sAlcoy%2C%20Alicante!5e0!3m2!1ses!2ses!4v1700000000000!5m2!1ses!2ses"
-            />
-          </div>
+          <h2 className="text-xl font-semibold text-neutral-900">Formulario rápido</h2>
           <ContactQuickForm />
         </div>
       </section>

--- a/src/app/en/blog/[slug]/page.tsx
+++ b/src/app/en/blog/[slug]/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { getAllPosts, getPostBySlug } from '@/lib/blog'
+import { renderMarkdown } from '@/lib/markdown'
+import {
+  absoluteUrl,
+  buildArticleJsonLd,
+  defaultOpenGraphImage,
+  siteMetadata
+} from '@/lib/seo'
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs'
+
+type BlogPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export const generateStaticParams = async () => {
+  const posts = await getAllPosts('en')
+  return posts.map(post => ({ slug: post.slug }))
+}
+
+export const generateMetadata = async ({ params }: BlogPageProps): Promise<Metadata> => {
+  const { slug } = await params
+  const post = await getPostBySlug(slug, 'en')
+  if (!post) {
+    return {
+      title: 'Post not found · La Tortugueta'
+    }
+  }
+
+  const url = absoluteUrl(`/en/blog/${post.slug}`)
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    alternates: {
+      canonical: url,
+      languages: {
+        es: `/blog/${post.slug}`,
+        ca: `/ca/blog/${post.slug}`,
+        en: `/en/blog/${post.slug}`
+      }
+    },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt || siteMetadata.description,
+      url,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+      siteName: siteMetadata.name,
+      images: [
+        {
+          url: post.image ? absoluteUrl(post.image) : defaultOpenGraphImage,
+          width: 1200,
+          height: 630,
+          alt: post.title
+        }
+      ]
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt || siteMetadata.description,
+      images: [post.image ? absoluteUrl(post.image) : defaultOpenGraphImage]
+    }
+  }
+}
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'long' }).format(new Date(value))
+
+export default async function BlogPostPageEn({ params }: BlogPageProps) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug, 'en')
+
+  if (!post) {
+    notFound()
+  }
+
+  const html = renderMarkdown(post.content)
+  const articleJsonLd = buildArticleJsonLd(post)
+  const breadcrumbs = [
+    { label: 'Home', href: '/en' },
+    { label: 'Blog', href: '/en/blog' },
+    { label: post.title, current: true }
+  ]
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+      <Breadcrumbs items={breadcrumbs} />
+      <article className="bg-white text-neutral-900">
+        <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-16 sm:px-6 lg:px-8">
+          <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">
+            {formatDate(post.date)}
+          </p>
+          <h1 className="text-4xl font-semibold text-neutral-900">{post.title}</h1>
+          <p className="text-sm uppercase tracking-[0.25em] text-neutral-500">
+            By {post.author}
+          </p>
+          <div
+            className="article-content"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-t border-neutral-200 pt-6 text-xs uppercase tracking-[0.3em] text-neutral-500">
+            <Link href="/en/blog" className="hover:text-neutral-900">
+              ← Back to blog
+            </Link>
+            <div className="flex flex-wrap gap-3">
+              {post.tags.map(tag => (
+                <span key={tag} className="rounded-full border border-neutral-200 px-3 py-1">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </article>
+    </>
+  )
+}

--- a/src/app/en/blog/page.tsx
+++ b/src/app/en/blog/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
 
 export default async function BlogIndexPageEn() {
     const posts = await getAllPosts('en')
-    const blogJsonLd = buildBlogListingJsonLd(posts)
+    const blogJsonLd = buildBlogListingJsonLd(posts, 'en')
 
     return (
         <>

--- a/src/app/en/calcetines-tradicionales/page.tsx
+++ b/src/app/en/calcetines-tradicionales/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { ProductImage } from '@/components/common/ProductImage'
+import { getAllProducts } from '@/lib/products'
+import {
+  absoluteUrl,
+  buildBreadcrumbJsonLd,
+  buildFaqPageJsonLd,
+  buildProductAltText,
+  siteMetadata
+} from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Traditional Valencian Socks Handmade',
+  description:
+    'Discover our traditional Valencian socks, handmade with artisanal techniques. Unique designs, natural materials and bespoke orders.',
+  alternates: {
+    canonical: absoluteUrl('/en/calcetines-tradicionales'),
+    languages: {
+      es: '/calcetines-tradicionales',
+      ca: '/ca/calcetines-tradicionales',
+      en: '/en/calcetines-tradicionales'
+    }
+  },
+  openGraph: {
+    title: 'Traditional Valencian Socks | La Tortugueta',
+    description:
+      'Pillar page about traditional Valencian socks, artisanal models, production process and bespoke orders.',
+    url: absoluteUrl('/en/calcetines-tradicionales'),
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Traditional Valencian Socks | La Tortugueta',
+    description:
+      'Complete guide to traditional Valencian socks, artisanal models and the current collection.'
+  }
+}
+
+const faqEntries = [
+  {
+    question: 'What are traditional Valencian socks?',
+    answer:
+      'They are socks inspired by historical Valencian dress, made with quality yarns and artisanal finishes for folk dress, dances and historical clothing.'
+  },
+  {
+    question: 'How are they different from industrial socks?',
+    answer:
+      'The main difference lies in the design care, yarn selection, size and colour personalisation, and the artisanal process shaped around traditional aesthetics.'
+  },
+  {
+    question: 'How do I choose the right size?',
+    answer:
+      'We work from the real foot size and can adapt leg height or width when needed. If you are unsure, the best option is to contact us before production.'
+  },
+  {
+    question: 'Can colours or motifs be customised?',
+    answer:
+      'Yes. La Tortugueta works by order and can adapt colours, combinations and historical references so the sock fits your dress or an old family model.'
+  }
+]
+
+export default async function TraditionalSocksPageEn() {
+  const products = await getAllProducts()
+  const featuredProducts = products
+    .filter(product => product.price > 0 && product.image)
+    .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
+    .slice(0, 6)
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: 'Home', url: '/en' },
+    { name: 'Traditional Socks', url: '/en/calcetines-tradicionales' }
+  ])
+  const faqJsonLd = buildFaqPageJsonLd(faqEntries)
+
+  return (
+    <div className="bg-white text-neutral-900">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbJsonLd, faqJsonLd]) }}
+      />
+
+      <section className="border-b border-neutral-200 bg-gradient-to-b from-stone-50 via-white to-white">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="max-w-4xl space-y-6">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Main guide</p>
+            <h1 className="text-4xl font-semibold text-neutral-900 sm:text-5xl">
+              Traditional Valencian Socks
+            </h1>
+            <p className="text-lg leading-relaxed text-neutral-700">
+              At La Tortugueta we understand traditional socks as an essential part of dress, not a secondary
+              accessory. That is why we document old models, study materials and reproduce each design with an
+              artisanal perspective that connects textile memory with present-day use.
+            </p>
+            <p className="max-w-3xl text-sm leading-relaxed text-neutral-600">
+              This page gathers the foundations of our collection, our working process and the answers most people
+              look for when searching for traditional Valencian socks for folk dress, dances or historical reenactment.
+            </p>
+            <div className="flex flex-wrap gap-4 pt-2 text-xs uppercase tracking-[0.3em]">
+              <Link href="/#catalogo" className="rounded-full bg-neutral-900 px-6 py-3 text-white">
+                View collection
+              </Link>
+              <Link href="/contacto" className="rounded-full border border-neutral-900 px-6 py-3 text-neutral-900">
+                Ask for advice
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+          <div className="space-y-6 text-sm leading-relaxed text-neutral-700">
+            <h2 className="text-3xl font-semibold text-neutral-900">A living textile tradition</h2>
+            <p>
+              Traditional Valencian socks are part of the visual language of popular dress. They speak about craft,
+              territory and a way of dressing where every detail has intention. Pattern, leg height, colour and texture
+              all change the final balance of the outfit.
+            </p>
+            <p>
+              Our work starts from archive and observation. We review historical models, study references kept in
+              private collections and translate that information into pieces that can still be worn comfortably today.
+            </p>
+            <p>
+              If you are searching for <strong>traditional Valencian socks</strong>, here you will find a living
+              collection. Some models are sober, some are more ornamental, but all of them follow the same logic:
+              quality materials, careful making and direct guidance before taking the order.
+            </p>
+            <p>
+              We also work with customisation. Many clients arrive with an old photograph, a family reference or a
+              very specific colour combination in mind. In those cases the catalogue is the starting point, not the
+              limit. You can review our <Link href="/colores" className="underline underline-offset-4">colour chart</Link>,
+              browse the <Link href="/en/blog" className="underline underline-offset-4">blog</Link> and contact us to adapt the piece.
+            </p>
+          </div>
+
+          <aside className="space-y-4 rounded-3xl border border-neutral-200 bg-stone-50 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Why choose them</p>
+            <h3 className="text-2xl font-semibold text-neutral-900">What we care for in every pair</h3>
+            <ul className="space-y-3 text-sm leading-relaxed text-neutral-700">
+              <li>Historical documentation and careful reinterpretation.</li>
+              <li>Yarn and colour selection designed for use and durability.</li>
+              <li>Made-to-order work adapted to size, leg height and colour combinations.</li>
+              <li>Direct attention to solve questions before confirming an order.</li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="border-y border-neutral-200 bg-neutral-50">
+        <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">Featured collection</p>
+              <h2 className="text-3xl font-semibold text-neutral-900">Artisanal models from the collection</h2>
+            </div>
+            <Link href="/#catalogo" className="text-xs uppercase tracking-[0.3em] text-neutral-600 underline underline-offset-4">
+              View full collection
+            </Link>
+          </div>
+
+          <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {featuredProducts.map((product, index) => (
+              <Link
+                key={product.id}
+                href={`/${product.id}`}
+                className="group space-y-4 rounded-3xl border border-neutral-200 bg-white p-5 transition hover:border-neutral-900"
+              >
+                <div className="relative aspect-[3/4] overflow-hidden rounded-2xl bg-white">
+                  <ProductImage
+                    imagePath={product.image}
+                    variant="thumb"
+                    alt={buildProductAltText({
+                      name: product.name,
+                      color: product.color,
+                      category: product.category,
+                      viewIndex: index
+                    })}
+                    fill
+                    className="object-contain transition-transform duration-500 group-hover:scale-[1.03]"
+                    sizes="(min-width: 1024px) 28vw, (min-width: 640px) 45vw, 90vw"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">
+                    {product.category ?? 'Artisanal collection'}
+                  </p>
+                  <h3 className="text-lg font-semibold text-neutral-900">{product.name}</h3>
+                  <p className="text-sm text-neutral-600">{product.price.toFixed(2)} €</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-neutral-500">FAQ</p>
+            <h2 className="text-3xl font-semibold text-neutral-900">Frequently asked questions</h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {faqEntries.map(entry => (
+              <article key={entry.question} className="rounded-3xl border border-neutral-200 p-6">
+                <h3 className="text-lg font-semibold text-neutral-900">{entry.question}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-neutral-700">{entry.answer}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-neutral-200 bg-neutral-900 text-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 text-center sm:px-6 lg:px-8">
+          <p className="text-xs uppercase tracking-[0.35em] text-white/60">{siteMetadata.shortDescription}</p>
+          <h2 className="mt-4 text-3xl font-semibold">Find your next pair</h2>
+          <div className="mt-8 flex flex-wrap justify-center gap-4 text-xs uppercase tracking-[0.3em]">
+            <Link href="/#catalogo" className="rounded-full bg-white px-6 py-3 text-neutral-900">
+              View collection
+            </Link>
+            <Link href="/contacto" className="rounded-full border border-white/40 px-6 py-3 text-white">
+              Contact La Tortugueta
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/en/colores/page.tsx
+++ b/src/app/en/colores/page.tsx
@@ -1,11 +1,27 @@
 import React from 'react';
+import Link from 'next/link';
 import { YARN_COLORS } from '@/lib/colors/constants';
 import { ColorCatalogGrid } from '@/components/catalog/ColorCatalogGrid';
 import { Metadata } from 'next';
+import { absoluteUrl, siteMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = {
-    title: 'Color Catalog | La Tortugueta',
-    description: 'Explore our full color chart. Find the perfect shade for your custom socks.',
+    title: 'Color Chart | Traditional Valencian Socks',
+    description: 'Explore La Tortugueta’s color chart to choose tones and combinations for traditional Valencian socks and bespoke designs.',
+    alternates: {
+        canonical: absoluteUrl('/en/colores'),
+        languages: {
+            es: '/colores',
+            en: '/en/colores',
+            ca: '/ca/colores'
+        }
+    },
+    openGraph: {
+        title: `${siteMetadata.name} · Color chart`,
+        description: 'Review La Tortugueta’s color chart and choose the right shades for traditional Valencian socks and custom combinations.',
+        url: absoluteUrl('/en/colores'),
+        type: 'website'
+    }
 };
 
 export default function ColorCatalogPage() {
@@ -25,6 +41,17 @@ export default function ColorCatalogPage() {
                             </p>
                             <p>
                                 And do you know what&apos;s best? How it absorbs dye. The colors remain vivid, intense, and withstand wash after wash without losing that joy and without pilling. We bring it from far away, yes, but we dye and knit it here, in our land, in trusted workshops of a lifetime. Because to do things right, you have to mix the best from abroad with the mastery of home.
+                            </p>
+                        </div>
+
+                        <div className="rounded-3xl border border-gray-200 bg-white px-6 py-5 text-left max-w-3xl mx-auto">
+                            <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Recommended guide</p>
+                            <p className="mt-2 text-base text-gray-800">
+                                Before choosing combinations, visit our page about{' '}
+                                <Link href="/en/calcetines-tradicionales" className="underline underline-offset-4">
+                                    traditional Valencian socks
+                                </Link>{' '}
+                                to understand styles, materials and how each model fits within the full outfit.
                             </p>
                         </div>
 

--- a/src/app/en/quienes-somos/page.tsx
+++ b/src/app/en/quienes-somos/page.tsx
@@ -7,8 +7,8 @@ import { dictionaries } from '@/i18n/dictionaries'
 export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
-    title: dictionaries.en.about.metaTitle,
-    description: dictionaries.en.about.metaDescription,
+    title: 'About Us | Traditional Valencian Socks Workshop',
+    description: 'Meet La Tortugueta, a family workshop crafting traditional Valencian socks since 1989. Heritage, craftsmanship and bespoke orders from Alcoi.',
     alternates: {
         canonical: absoluteUrl('/en/quienes-somos'),
         languages: {
@@ -18,10 +18,15 @@ export const metadata: Metadata = {
         }
     },
     openGraph: {
-        title: `${siteMetadata.name} · ${dictionaries.en.about.metaTitle}`,
-        description: dictionaries.en.about.metaDescription,
+        title: `${siteMetadata.name} · About us`,
+        description: 'Discover the story of La Tortugueta, a family workshop focused on traditional Valencian socks, historical references and made-to-order craftsmanship.',
         url: absoluteUrl('/en/quienes-somos'),
         type: 'website'
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: `${siteMetadata.name} · About us`,
+        description: 'Family workshop for traditional Valencian socks since 1989, with heritage craft and bespoke production.'
     }
 }
 

--- a/src/app/quienes-somos/page.tsx
+++ b/src/app/quienes-somos/page.tsx
@@ -6,9 +6,9 @@ import { AboutContent } from '@/components/about/AboutContent'
 export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
-  title: 'Quiénes somos',
+  title: 'Quiénes Somos | Taller Artesano de Calcetines Tradicionales',
   description:
-    'Calcetería artesana nacida en Alcoi en 1989. Taller familiar que documenta modelos históricos, trabaja bajo pedido y apuesta por materiales de proximidad.',
+    'Conoce La Tortugueta: taller artesano de calcetines tradicionales valencianos desde 1989. Historia, oficio familiar y encargos personalizados desde Alcoi.',
   alternates: {
     canonical: absoluteUrl('/quienes-somos'),
     languages: {
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: `${siteMetadata.name} · Quiénes somos`,
     description:
-      'Taller familiar fundado por Macu García: tejemos calcetines tradicionales, restauramos modelos antiguos y trabajamos bajo pedido con materiales locales.',
+      'Descubre la historia de La Tortugueta, el taller familiar de Macu García especializado en calcetines tradicionales valencianos y reproducciones históricas.',
     url: absoluteUrl('/quienes-somos'),
     type: 'website'
   },
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: `${siteMetadata.name} · Quiénes somos`,
     description:
-      'Calcetería artesana nacida en Alcoi y activa desde 1989. Oficio familiar con sello oficial de artesanía.'
+      'Taller artesano de calcetines tradicionales valencianos desde 1989. Historia, oficio familiar y trabajo bajo pedido.'
   }
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,13 +6,26 @@ import { absoluteUrl, getPrimaryProductImage } from '@/lib/seo'
 export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [products, posts] = await Promise.all([getAllProducts(), getAllPosts()])
+  const [products, postsEs, postsEn, postsCa] = await Promise.all([
+    getAllProducts(),
+    getAllPosts('es'),
+    getAllPosts('en'),
+    getAllPosts('ca')
+  ])
   const entries: MetadataRoute.Sitemap = [
     { url: absoluteUrl('/'), changeFrequency: 'daily', priority: 1 },
+    { url: absoluteUrl('/en'), changeFrequency: 'daily', priority: 0.8 },
+    { url: absoluteUrl('/ca'), changeFrequency: 'daily', priority: 0.8 },
     { url: absoluteUrl('/calcetines-tradicionales'), changeFrequency: 'weekly', priority: 0.9 },
+    { url: absoluteUrl('/en/calcetines-tradicionales'), changeFrequency: 'weekly', priority: 0.8 },
+    { url: absoluteUrl('/ca/calcetines-tradicionales'), changeFrequency: 'weekly', priority: 0.8 },
     { url: absoluteUrl('/colores'), changeFrequency: 'monthly', priority: 0.8 },
     { url: absoluteUrl('/blog'), changeFrequency: 'weekly', priority: 0.8 },
+    { url: absoluteUrl('/en/blog'), changeFrequency: 'weekly', priority: 0.7 },
+    { url: absoluteUrl('/ca/blog'), changeFrequency: 'weekly', priority: 0.7 },
     { url: absoluteUrl('/quienes-somos'), changeFrequency: 'monthly', priority: 0.5 },
+    { url: absoluteUrl('/en/quienes-somos'), changeFrequency: 'monthly', priority: 0.4 },
+    { url: absoluteUrl('/ca/quienes-somos'), changeFrequency: 'monthly', priority: 0.4 },
     { url: absoluteUrl('/contacto'), changeFrequency: 'monthly', priority: 0.5 }
   ]
 
@@ -29,11 +42,29 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   )
 
   entries.push(
-    ...posts.map(post => ({
+    ...postsEs.map(post => ({
       url: absoluteUrl(`/blog/${post.slug}`),
       lastModified: post.date ? new Date(post.date) : now,
       changeFrequency: 'monthly' as const,
       priority: 0.6
+    }))
+  )
+
+  entries.push(
+    ...postsEn.map(post => ({
+      url: absoluteUrl(`/en/blog/${post.slug}`),
+      lastModified: post.date ? new Date(post.date) : now,
+      changeFrequency: 'monthly' as const,
+      priority: 0.5
+    }))
+  )
+
+  entries.push(
+    ...postsCa.map(post => ({
+      url: absoluteUrl(`/ca/blog/${post.slug}`),
+      lastModified: post.date ? new Date(post.date) : now,
+      changeFrequency: 'monthly' as const,
+      priority: 0.5
     }))
   )
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,6 +9,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [products, posts] = await Promise.all([getAllProducts(), getAllPosts()])
   const entries: MetadataRoute.Sitemap = [
     { url: absoluteUrl('/'), changeFrequency: 'daily', priority: 1 },
+    { url: absoluteUrl('/calcetines-tradicionales'), changeFrequency: 'weekly', priority: 0.9 },
     { url: absoluteUrl('/colores'), changeFrequency: 'monthly', priority: 0.8 },
     { url: absoluteUrl('/blog'), changeFrequency: 'weekly', priority: 0.8 },
     { url: absoluteUrl('/quienes-somos'), changeFrequency: 'monthly', priority: 0.5 },

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -68,6 +68,17 @@ export function AboutContent({ totalDesigns, yearsWeaving, locale }: AboutConten
                 ))}
 
                 <section className="space-y-3">
+                    <h2 className="text-2xl font-semibold text-neutral-900">Calcetines tradicionales valencianos</h2>
+                    <p>
+                        Si quieres una visión más práctica de nuestros modelos, materiales y formas de encargo, hemos preparado una guía específica sobre{' '}
+                        <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                            calcetines tradicionales valencianos
+                        </Link>.
+                        Ahí reunimos la colección, preguntas frecuentes y recursos para elegir mejor cada par.
+                    </p>
+                </section>
+
+                <section className="space-y-3">
                     <h2 className="text-2xl font-semibold text-neutral-900">{t.contactTitle}</h2>
                     <p>
                         {t.contactText}{' '}

--- a/src/components/about/AboutContent.tsx
+++ b/src/components/about/AboutContent.tsx
@@ -11,6 +11,8 @@ interface AboutContentProps {
 export function AboutContent({ totalDesigns, yearsWeaving, locale }: AboutContentProps) {
     const t = dictionaries[locale].about
     const whatsappDisplay = '+34 653 45 22 49'
+    const pillarHref = locale === 'es' ? '/calcetines-tradicionales' : `/${locale}/calcetines-tradicionales`
+    const catalogHref = locale === 'es' ? '/catalogo' : `/${locale}`
 
     const sections = [
         {
@@ -71,7 +73,7 @@ export function AboutContent({ totalDesigns, yearsWeaving, locale }: AboutConten
                     <h2 className="text-2xl font-semibold text-neutral-900">Calcetines tradicionales valencianos</h2>
                     <p>
                         Si quieres una visión más práctica de nuestros modelos, materiales y formas de encargo, hemos preparado una guía específica sobre{' '}
-                        <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                        <Link href={pillarHref} className="underline underline-offset-4">
                             calcetines tradicionales valencianos
                         </Link>.
                         Ahí reunimos la colección, preguntas frecuentes y recursos para elegir mejor cada par.
@@ -94,7 +96,7 @@ export function AboutContent({ totalDesigns, yearsWeaving, locale }: AboutConten
                 </section>
 
                 <div className="flex flex-wrap gap-4 text-xs uppercase tracking-[0.35em] text-neutral-500">
-                    <Link href={locale === 'es' ? "/catalogo" : `/${locale}`} className="rounded-full border border-neutral-900 px-6 py-3">
+                    <Link href={catalogHref} className="rounded-full border border-neutral-900 px-6 py-3">
                         {t.viewCatalog}
                     </Link>
                     <a href={WHATSAPP_LINK} className="rounded-full border border-neutral-900 px-6 py-3">

--- a/src/components/admin/ProductForm.tsx
+++ b/src/components/admin/ProductForm.tsx
@@ -320,6 +320,26 @@ export function ProductForm({
           />
         </label>
         <label className="text-xs uppercase tracking-[0.3em] text-neutral-500">
+          Resumen en valencià
+          <textarea
+            rows={3}
+            value={String(metadata.storyBodyVa ?? '')}
+            onChange={event => handleMetadataChange('storyBodyVa', event.target.value)}
+            className="mt-2 w-full rounded-3xl border border-neutral-300 px-4 py-3 text-sm text-neutral-900 focus:border-neutral-900 focus:outline-none focus:ring-0"
+            placeholder="Versió breu en valencià per a reforçar la fitxa sense duplicar la pàgina."
+          />
+        </label>
+        <label className="text-xs uppercase tracking-[0.3em] text-neutral-500">
+          Meta description SEO
+          <textarea
+            rows={2}
+            value={String(metadata.storyMetaDescription ?? '')}
+            onChange={event => handleMetadataChange('storyMetaDescription', event.target.value)}
+            className="mt-2 w-full rounded-3xl border border-neutral-300 px-4 py-3 text-sm text-neutral-900 focus:border-neutral-900 focus:outline-none focus:ring-0"
+            placeholder="Texto corto para Google con keyword y tono editorial."
+          />
+        </label>
+        <label className="text-xs uppercase tracking-[0.3em] text-neutral-500">
           Fotos históricas (URLs separadas por coma)
           <input
             type="text"

--- a/src/components/admin/sales/SalesDashboard.tsx
+++ b/src/components/admin/sales/SalesDashboard.tsx
@@ -80,6 +80,16 @@ export function SalesDashboard() {
         setEditForm({ ...sale })
     }
 
+    const getCatalogPrice = (sale: any) => {
+        const catalogPrice = typeof sale.catalog_price === 'number' ? sale.catalog_price : null
+        if (catalogPrice !== null && !Number.isNaN(catalogPrice)) {
+            return catalogPrice
+        }
+
+        const currentPrice = typeof sale.product_price === 'number' ? sale.product_price : 0
+        return sale.is_wholesale ? currentPrice * 2 : currentPrice
+    }
+
     const saveEdit = async () => {
         if (!editingId) return
         try {
@@ -245,13 +255,8 @@ export function SalesDashboard() {
                                                             value={editForm.is_wholesale ? 'wholesale' : 'retail'}
                                                             onChange={e => {
                                                                 const isWholesale = e.target.value === 'wholesale'
-                                                                let newPrice = parseFloat(editForm.product_price) || 0
-
-                                                                if (isWholesale && !editForm.is_wholesale) {
-                                                                    newPrice = newPrice * 0.5
-                                                                } else if (!isWholesale && editForm.is_wholesale) {
-                                                                    newPrice = newPrice * 2
-                                                                }
+                                                                const catalogPrice = getCatalogPrice(editForm)
+                                                                const newPrice = isWholesale ? catalogPrice * 0.5 : catalogPrice
 
                                                                 setEditForm({
                                                                     ...editForm,
@@ -301,13 +306,8 @@ export function SalesDashboard() {
                                                                 if (!confirm(`¿Cambiar a ${sale.is_wholesale ? 'Por menor' : 'Por mayor'}? El precio se actualizará.`)) return
 
                                                                 const newIsWholesale = !sale.is_wholesale
-                                                                let newPrice = sale.product_price || 0
-
-                                                                if (newIsWholesale) {
-                                                                    newPrice = newPrice * 0.5
-                                                                } else {
-                                                                    newPrice = newPrice * 2
-                                                                }
+                                                                const catalogPrice = getCatalogPrice(sale)
+                                                                const newPrice = newIsWholesale ? catalogPrice * 0.5 : catalogPrice
 
                                                                 try {
                                                                     const res = await fetch(`/api/admin/sales/${sale.id}`, {

--- a/src/components/blog/BlogIndex.tsx
+++ b/src/components/blog/BlogIndex.tsx
@@ -24,6 +24,8 @@ export function BlogIndex({ posts, locale }: BlogIndexProps) {
         { label: navT.home, href: locale === 'es' ? '/' : `/${locale}` },
         { label: navT.blog, current: true }
     ]
+    const pillarHref = locale === 'es' ? '/calcetines-tradicionales' : `/${locale}/calcetines-tradicionales`
+    const catalogHref = locale === 'es' ? '/#catalogo' : `/${locale}#catalogo`
 
     return (
         <div className="bg-white text-neutral-900">
@@ -105,13 +107,13 @@ export function BlogIndex({ posts, locale }: BlogIndexProps) {
                                 <div className="mt-3 space-y-2 text-sm text-neutral-700">
                                     <p>
                                         Empieza por nuestra guía de{' '}
-                                        <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                                        <Link href={pillarHref} className="underline underline-offset-4">
                                             calcetines tradicionales valencianos
                                         </Link>.
                                     </p>
                                     <p>
                                         También puedes volver al{' '}
-                                        <Link href="/#catalogo" className="underline underline-offset-4">
+                                        <Link href={catalogHref} className="underline underline-offset-4">
                                             catálogo completo
                                         </Link>{' '}
                                         o revisar la{' '}

--- a/src/components/blog/BlogIndex.tsx
+++ b/src/components/blog/BlogIndex.tsx
@@ -99,6 +99,28 @@ export function BlogIndex({ posts, locale }: BlogIndexProps) {
                                     </div>
                                 ))}
                             </nav>
+
+                            <div className="rounded-3xl border border-neutral-200 bg-stone-50 p-4">
+                                <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Nuestros productos</p>
+                                <div className="mt-3 space-y-2 text-sm text-neutral-700">
+                                    <p>
+                                        Empieza por nuestra guía de{' '}
+                                        <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                                            calcetines tradicionales valencianos
+                                        </Link>.
+                                    </p>
+                                    <p>
+                                        También puedes volver al{' '}
+                                        <Link href="/#catalogo" className="underline underline-offset-4">
+                                            catálogo completo
+                                        </Link>{' '}
+                                        o revisar la{' '}
+                                        <Link href="/colores" className="underline underline-offset-4">
+                                            carta de colores
+                                        </Link>.
+                                    </p>
+                                </div>
+                            </div>
                         </aside>
                     </div>
                 )}

--- a/src/components/catalog/ProductGrid.tsx
+++ b/src/components/catalog/ProductGrid.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { ProductImage } from '@/components/common/ProductImage'
+import { buildProductAltText } from '@/lib/seo'
 
 import type { CatalogProduct, FilterState } from './catalogFiltering'
 
@@ -243,7 +244,11 @@ export const ProductGrid = ({
                     <ProductImage
                       imagePath={product.image}
                       variant="thumb"
-                      alt={product.name}
+                      alt={buildProductAltText({
+                        name: product.name,
+                        category: product.category,
+                        viewIndex: realIndex
+                      })}
                       fill
                       className="object-contain transition-transform duration-700 group-hover:scale-[1.03]"
                       sizes={

--- a/src/components/home/SeoContentSection.tsx
+++ b/src/components/home/SeoContentSection.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 export function SeoContentSection() {
     return (
         <section className="border-t border-neutral-200 bg-white" aria-labelledby="seo-title">
@@ -22,6 +24,12 @@ export function SeoContentSection() {
                             <p>
                                 Nuestros <strong>calcetines artesanales</strong> están pensados para resistir y lucir en actos de <strong>Fallas</strong>, <strong>Grupos de Danses</strong> y recreación histórica. Utilizamos materiales nobles y técnicas respetuosas para ofrecer un producto auténtico y de máxima calidad.
                             </p>
+                            <p>
+                                Si quieres entender mejor qué hace especial a un par bien resuelto, visita nuestra página sobre{' '}
+                                <Link href="/calcetines-tradicionales" className="underline underline-offset-4">
+                                    calcetines tradicionales valencianos
+                                </Link>.
+                            </p>
                         </div>
 
                         <div className="space-y-6">
@@ -34,6 +42,14 @@ export function SeoContentSection() {
                             <p>
                                 Trabajamos mano a mano con quienes aman la fiesta para asegurar que el tono del hilo y el diseño encajen perfectamente. Si buscas <strong>calcetines bordados</strong> hechos con rigor y cariño, aquí encontrarás el detalle que marca la diferencia.
                             </p>
+                            <div className="pt-2">
+                                <Link
+                                    href="/calcetines-tradicionales"
+                                    className="inline-flex rounded-full border border-neutral-900 px-6 py-3 text-xs uppercase tracking-[0.3em] text-neutral-900"
+                                >
+                                    Ver colección
+                                </Link>
+                            </div>
                         </div>
                     </div>
                 </article>

--- a/src/components/home/TopVisitedSection.tsx
+++ b/src/components/home/TopVisitedSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import type { CatalogProductSummary } from '@/components/catalog/prepareCatalogProducts'
 import { ProductImage } from '@/components/common/ProductImage'
 import { dictionaries } from '@/i18n/dictionaries'
+import { buildProductAltText } from '@/lib/seo'
 
 interface TopVisitedSectionProps {
   products: CatalogProductSummary[]
@@ -48,7 +49,10 @@ export function TopVisitedSection({ products, dictionary }: TopVisitedSectionPro
                   <ProductImage
                     imagePath={product.image}
                     variant="thumb"
-                    alt={product.name}
+                    alt={buildProductAltText({
+                      name: product.name,
+                      category: product.category
+                    })}
                     fill
                     className="object-contain transition-transform duration-500 group-hover:scale-105"
                     sizes="(min-width: 1024px) 30vw, (min-width: 640px) 45vw, 90vw"

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -31,6 +31,7 @@ export function HeaderNav() {
                 // Adjust href for locale only for supported routes
                 let href = link.href
                 const isSupportedRoute =
+                    link.href === '/calcetines-tradicionales' ||
                     link.href === '/blog' ||
                     link.href.startsWith('/blog/') ||
                     link.href === '/quienes-somos'

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -21,6 +21,7 @@ export function LanguageSwitcher() {
         .replace(/\/$/, '') // Remove trailing slash
 
     const isSupportedRoute =
+        cleanPath === '/calcetines-tradicionales' ||
         cleanPath === '/blog' ||
         cleanPath.startsWith('/blog/') ||
         cleanPath === '/quienes-somos' ||
@@ -74,4 +75,3 @@ export function LanguageSwitcher() {
         </div>
     )
 }
-

--- a/src/components/layout/LayoutShell.tsx
+++ b/src/components/layout/LayoutShell.tsx
@@ -38,12 +38,15 @@ export function LayoutShell({ children }: LayoutShellProps) {
         <div className="mx-auto flex max-w-6xl 3xl:max-w-8xl flex-col gap-6 px-4 py-12 text-sm text-neutral-500 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
           <div className="flex flex-col gap-4 max-w-xl">
             <p className="leading-relaxed">
-              Catálogo vivo de calcetería artesanal documentado y conservado por La Tortugueta. Ediciones
-              limitadas disponibles bajo pedido personalizado.
+              Catálogo vivo de calcetería artesanal documentado y conservado por La Tortugueta. Descubre nuestros
+              <Link href="/calcetines-tradicionales" className="mx-1 underline underline-offset-4">
+                calcetines tradicionales valencianos
+              </Link>
+              y las ediciones limitadas disponibles bajo pedido personalizado.
             </p>
             <address className="flex flex-col gap-1 text-xs text-neutral-500 not-italic">
-              <p>C/ San Nicolás 12, 03801 Alcoy (Alicante)</p>
               <p>WhatsApp: +34 653 452 249</p>
+              <p>Email: hola@latortugueta.com</p>
             </address>
           </div>
           <div className="flex flex-wrap gap-4 text-xs uppercase tracking-[0.3em]">

--- a/src/components/product/ProductShowcase.tsx
+++ b/src/components/product/ProductShowcase.tsx
@@ -15,6 +15,7 @@ import {
   getProductImageVariant
 } from '@/lib/images'
 import { WHATSAPP_LINK } from '@/lib/contact'
+import { extractProductStory } from '@/lib/productEditorial'
 import { buildProductAltText } from '@/lib/seo'
 import { uploadProductImage } from '@/lib/client/uploadProductImage'
 import { ColorSelectionModal, SelectedColors } from '@/components/product/ColorSelectionModal'
@@ -44,44 +45,6 @@ const ProductAdminPanel = dynamic(() => import('./ProductAdminPanel'), {
   ssr: false,
   loading: () => null
 })
-
-type ProductStory = {
-  title: string
-  body: string
-  origin?: string
-  cost?: string
-  images: string[]
-}
-
-const extractProductStory = (product: Product): ProductStory | null => {
-  const metadata = product.metadata ?? {}
-  const title = typeof metadata.storyTitle === 'string' ? metadata.storyTitle.trim() : ''
-  const body = typeof metadata.storyBody === 'string' ? metadata.storyBody.trim() : ''
-  const origin = typeof metadata.storyOrigin === 'string' ? metadata.storyOrigin.trim() : ''
-  const cost = typeof metadata.storyCost === 'string' ? metadata.storyCost.trim() : ''
-  const imagesRaw = metadata.storyImages
-  let images: string[] = []
-  if (Array.isArray(imagesRaw)) {
-    images = imagesRaw.map(value => String(value ?? '').trim()).filter(Boolean)
-  } else if (typeof imagesRaw === 'string') {
-    images = imagesRaw
-      .split(',')
-      .map(value => value.trim())
-      .filter(Boolean)
-  }
-
-  if (!title && !body && !origin && !cost && images.length === 0) {
-    return null
-  }
-
-  return {
-    title: title || product.name,
-    body,
-    origin,
-    cost,
-    images
-  }
-}
 
 export function ProductShowcase({
   product,
@@ -836,6 +799,65 @@ export function ProductShowcase({
               </div>
 
               <div className="space-y-4 text-sm leading-relaxed text-neutral-600">
+                {story && (
+                  <div className="rounded-3xl border border-neutral-200 bg-neutral-50 p-5">
+                    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+                      <div className="space-y-4">
+                        <div className="space-y-2">
+                          <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Historia</p>
+                          <h3 className="text-2xl font-semibold text-neutral-900">{story.title}</h3>
+                        </div>
+                        {(story.origin || story.cost) && (
+                          <dl className="grid gap-4 sm:grid-cols-2 text-sm text-neutral-600">
+                            {story.origin && (
+                              <div>
+                                <dt className="text-xs uppercase tracking-[0.3em] text-neutral-500">Procedencia</dt>
+                                <dd className="mt-1 text-neutral-800">{story.origin}</dd>
+                              </div>
+                            )}
+                            {story.cost && (
+                              <div>
+                                <dt className="text-xs uppercase tracking-[0.3em] text-neutral-500">Coste / dedicación</dt>
+                                <dd className="mt-1 text-neutral-800">{story.cost}</dd>
+                              </div>
+                            )}
+                          </dl>
+                        )}
+                        {story.body && <p className="text-neutral-700">{story.body}</p>}
+                        {story.bodyVa && (
+                          <div className="rounded-2xl border border-neutral-200 bg-white px-4 py-3">
+                            <p className="text-[11px] uppercase tracking-[0.3em] text-neutral-500">
+                              En valencià
+                            </p>
+                            <p className="mt-2 text-neutral-700">{story.bodyVa}</p>
+                          </div>
+                        )}
+                      </div>
+                      {story.images.length > 0 && (
+                        <div className="grid grid-cols-2 gap-3">
+                          {story.images.map(url => (
+                            <div
+                              key={url}
+                              className="relative h-32 overflow-hidden rounded-2xl border border-neutral-100 bg-white"
+                            >
+                              <ProductImage
+                                imagePath={url}
+                                alt={buildProductAltText({
+                                  name: product.name,
+                                  color: product.color,
+                                  category: product.category
+                                })}
+                                fill
+                                className="object-cover"
+                                sizes="180px"
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
                 <p>
                   Elaboración artesanal en talleres valencianos. Cada par se documenta en fotografía de
                   estudio para mostrar con precisión la textura y la caída del tejido.
@@ -872,58 +894,6 @@ export function ProductShowcase({
           </div>
         </div>
       </section>
-
-      {story && (
-        <section className="border-b border-neutral-200 bg-neutral-50">
-          <div className="mx-auto max-w-6xl 3xl:max-w-8xl px-4 py-16 sm:px-6 lg:px-8">
-            <div className="grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)]">
-              <div className="space-y-4">
-                <p className="text-xs uppercase tracking-[0.3em] text-neutral-500">Historia</p>
-                <h3 className="text-2xl font-semibold text-neutral-900">{story.title}</h3>
-                {(story.origin || story.cost) && (
-                  <dl className="grid gap-4 sm:grid-cols-2 text-sm text-neutral-600">
-                    {story.origin && (
-                      <div>
-                        <dt className="text-xs uppercase tracking-[0.3em] text-neutral-500">Procedencia</dt>
-                        <dd className="mt-1 text-neutral-800">{story.origin}</dd>
-                      </div>
-                    )}
-                    {story.cost && (
-                      <div>
-                        <dt className="text-xs uppercase tracking-[0.3em] text-neutral-500">Coste / dedicación</dt>
-                        <dd className="mt-1 text-neutral-800">{story.cost}</dd>
-                      </div>
-                    )}
-                  </dl>
-                )}
-                {story.body && <p className="text-neutral-700">{story.body}</p>}
-              </div>
-              {story.images.length > 0 && (
-                <div className="grid grid-cols-2 gap-3">
-                  {story.images.map(url => (
-                    <div
-                      key={url}
-                      className="relative h-32 overflow-hidden rounded-2xl border border-neutral-100 bg-white"
-                    >
-                      <ProductImage
-                        imagePath={url}
-                        alt={buildProductAltText({
-                          name: product.name,
-                          color: product.color,
-                          category: product.category
-                        })}
-                        fill
-                        className="object-cover"
-                        sizes="180px"
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
-      )}
 
       {lightboxOpen && gallery.length > 0 && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 px-4">

--- a/src/components/product/ProductShowcase.tsx
+++ b/src/components/product/ProductShowcase.tsx
@@ -15,6 +15,7 @@ import {
   getProductImageVariant
 } from '@/lib/images'
 import { WHATSAPP_LINK } from '@/lib/contact'
+import { buildProductAltText } from '@/lib/seo'
 import { uploadProductImage } from '@/lib/client/uploadProductImage'
 import { ColorSelectionModal, SelectedColors } from '@/components/product/ColorSelectionModal'
 import { Palette } from 'lucide-react'
@@ -477,7 +478,12 @@ export function ProductShowcase({
                   <ProductImage
                     imagePath={activeImage}
                     variant="full"
-                    alt={`${product.name} · ${product.category ?? 'calcetines artesanales'} · vista ${activeIndex + 1}`}
+                    alt={buildProductAltText({
+                      name: product.name,
+                      color: product.color,
+                      category: product.category,
+                      viewIndex: activeIndex
+                    })}
                     fill
                     priority
                     fetchPriority={activeIndex === 0 ? 'high' : 'auto'}
@@ -623,7 +629,12 @@ export function ProductShowcase({
                         <ProductImage
                           imagePath={photo}
                           variant="thumb"
-                          alt={`Miniatura ${index + 1} · ${product.name} · ${product.color || 'color artesanal'}`}
+                          alt={buildProductAltText({
+                            name: product.name,
+                            color: product.color,
+                            category: product.category,
+                            viewIndex: index
+                          })}
                           fill
                           className="object-contain"
                           sizes="80px"
@@ -896,7 +907,11 @@ export function ProductShowcase({
                     >
                       <ProductImage
                         imagePath={url}
-                        alt={`Historia ${product.name}`}
+                        alt={buildProductAltText({
+                          name: product.name,
+                          color: product.color,
+                          category: product.category
+                        })}
                         fill
                         className="object-cover"
                         sizes="180px"
@@ -931,7 +946,12 @@ export function ProductShowcase({
             <ProductImage
               imagePath={activeImage}
               variant="full"
-              alt={`${product.name} ampliada ${activeIndex + 1}`}
+              alt={buildProductAltText({
+                name: product.name,
+                color: product.color,
+                category: product.category,
+                viewIndex: activeIndex
+              })}
               fill
               className="object-contain"
               sizes="(min-width: 1024px) 50vw, 90vw"
@@ -986,7 +1006,10 @@ export function ProductShowcase({
                         <ProductImage
                           imagePath={item.image}
                           variant="thumb"
-                          alt={item.name}
+                          alt={buildProductAltText({
+                            name: item.name,
+                            category: item.category
+                          })}
                           fill
                           className="object-contain transition-transform duration-500 group-hover:scale-105"
                           sizes="(min-width: 1280px) 20vw, (min-width: 1024px) 25vw, 45vw"
@@ -1044,7 +1067,10 @@ export function ProductShowcase({
                         <ProductImage
                           imagePath={item.image}
                           variant="thumb"
-                          alt={item.name}
+                          alt={buildProductAltText({
+                            name: item.name,
+                            category: item.category
+                          })}
                           fill
                           className="object-contain transition-transform duration-500 group-hover:scale-105"
                           sizes="(min-width: 1280px) 20vw, (min-width: 1024px) 25vw, 45vw"

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,7 +7,6 @@ export type NavigationLink = {
 }
 
 export const primaryNavLinks: NavigationLink[] = [
-  { label: 'Calcetines Tradicionales', href: '/calcetines-tradicionales' },
   { label: 'Catálogo', href: '/#colecciones' },
   { label: 'Colores', href: '/colores' },
   { label: 'Blog', href: '/blog' },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,6 +7,7 @@ export type NavigationLink = {
 }
 
 export const primaryNavLinks: NavigationLink[] = [
+  { label: 'Calcetines Tradicionales', href: '/calcetines-tradicionales' },
   { label: 'Catálogo', href: '/#colecciones' },
   { label: 'Colores', href: '/colores' },
   { label: 'Blog', href: '/blog' },
@@ -16,6 +17,7 @@ export const primaryNavLinks: NavigationLink[] = [
 ]
 
 export const footerNavLinks: NavigationLink[] = [
+  { label: 'Calcetines Tradicionales', href: '/calcetines-tradicionales' },
   { label: 'Contacto', href: '/contacto' },
   { label: 'Blog', href: '/blog' },
   { label: 'Colecciones', href: '/#colecciones' },

--- a/src/lib/productEditorial.ts
+++ b/src/lib/productEditorial.ts
@@ -1,0 +1,68 @@
+import type { Product } from '@/lib/products'
+
+export type ProductEditorialStory = {
+  title: string
+  body: string
+  bodyVa?: string
+  origin?: string
+  cost?: string
+  metaDescription?: string
+  images: string[]
+}
+
+const readTrimmedString = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+
+export const extractProductStory = (product: Product): ProductEditorialStory | null => {
+  const metadata = product.metadata ?? {}
+  const title = readTrimmedString(metadata.storyTitle)
+  const body = readTrimmedString(metadata.storyBody)
+  const bodyVa = readTrimmedString(metadata.storyBodyVa)
+  const origin = readTrimmedString(metadata.storyOrigin)
+  const cost = readTrimmedString(metadata.storyCost)
+  const metaDescription = readTrimmedString(metadata.storyMetaDescription)
+  const imagesRaw = metadata.storyImages
+
+  let images: string[] = []
+  if (Array.isArray(imagesRaw)) {
+    images = imagesRaw.map(value => String(value ?? '').trim()).filter(Boolean)
+  } else if (typeof imagesRaw === 'string') {
+    images = imagesRaw
+      .split(',')
+      .map(value => value.trim())
+      .filter(Boolean)
+  }
+
+  if (!title && !body && !bodyVa && !origin && !cost && !metaDescription && images.length === 0) {
+    return null
+  }
+
+  return {
+    title: title || product.name,
+    body,
+    bodyVa: bodyVa || undefined,
+    origin: origin || undefined,
+    cost: cost || undefined,
+    metaDescription: metaDescription || undefined,
+    images
+  }
+}
+
+export const buildProductMetaDescription = (product: Product) => {
+  const story = extractProductStory(product)
+
+  if (story?.metaDescription) {
+    return story.metaDescription.slice(0, 160)
+  }
+
+  const baseDescription = (product.description || '').trim()
+  if (baseDescription.length >= 60) {
+    return baseDescription.slice(0, 160)
+  }
+
+  const storyBody = story?.body?.replace(/\s+/g, ' ').trim()
+  if (storyBody && storyBody.length >= 60) {
+    return storyBody.slice(0, 160)
+  }
+
+  return `Calcetines tradicionales valencianos modelo ${product.name}. Reproducción artesanal${product.color ? ` en color ${product.color}` : ''}. Perfectos para indumentaria tradicional y bailes regionales. Confección en Alcoi de alta calidad.`.slice(0, 160)
+}

--- a/src/lib/products/types.ts
+++ b/src/lib/products/types.ts
@@ -5,6 +5,8 @@ export type ProductMetadata = {
   storyOrigin?: string
   storyCost?: string
   storyBody?: string
+  storyBodyVa?: string
+  storyMetaDescription?: string
   storyImages?: string[] | string
   imagePlaceholders?: ImagePlaceholderMap
   imageReview?: Record<string, boolean>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -107,6 +107,16 @@ const toAbsoluteImageUrl = (value?: string) => {
 
 export const defaultOpenGraphImage = absoluteUrl('/og-image.png')
 
+const getLocalizedBlogBasePath = (locale?: string) => {
+  if (locale === 'en') {
+    return '/en/blog'
+  }
+  if (locale === 'ca') {
+    return '/ca/blog'
+  }
+  return '/blog'
+}
+
 const resolveProductImage = (image?: string) => {
   if (!image) {
     return undefined
@@ -290,16 +300,16 @@ export const buildProductJsonLd = (product: Product) => {
   }
 }
 
-export const buildBlogListingJsonLd = (posts: BlogPost[]) => ({
+export const buildBlogListingJsonLd = (posts: BlogPost[], locale: string = 'es') => ({
   '@context': 'https://schema.org',
   '@type': 'Blog',
   name: `${SITE_NAME} · Blog`,
-  url: absoluteUrl('/blog'),
+  url: absoluteUrl(getLocalizedBlogBasePath(locale)),
   blogPost: posts.slice(0, 12).map(post => ({
     '@type': 'BlogPosting',
     headline: post.title,
     datePublished: post.date,
-    url: absoluteUrl(`/blog/${post.slug}`),
+    url: absoluteUrl(`${getLocalizedBlogBasePath(post.locale)}/${post.slug}`),
     author: {
       '@type': 'Person',
       name: post.author
@@ -316,7 +326,7 @@ export const buildArticleJsonLd = (post: BlogPost) => ({
   description: post.excerpt || SITE_DESCRIPTION,
   mainEntityOfPage: {
     '@type': 'WebPage',
-    '@id': absoluteUrl(`/blog/${post.slug}`)
+    '@id': absoluteUrl(`${getLocalizedBlogBasePath(post.locale)}/${post.slug}`)
   },
   author: {
     '@type': 'Person',
@@ -330,7 +340,7 @@ export const buildArticleJsonLd = (post: BlogPost) => ({
       url: absoluteUrl('/icon-192.png')
     }
   },
-  image: defaultOpenGraphImage
+  image: post.image ? absoluteUrl(post.image) : defaultOpenGraphImage
 })
 
 export const buildBreadcrumbJsonLd = (items: { name: string; url: string }[]) => ({

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -181,6 +181,40 @@ export const buildCatalogJsonLd = (totalItems: number) => ({
   }
 })
 
+export const buildFaqPageJsonLd = (
+  entries: { question: string; answer: string }[]
+) => ({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: entries.map(entry => ({
+    '@type': 'Question',
+    name: entry.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: entry.answer
+    }
+  }))
+})
+
+export const buildProductAltText = (input: {
+  name: string
+  color?: string | null
+  category?: string | null
+  viewIndex?: number
+}) => {
+  const fragments = [
+    'calcetines tradicionales valencianos',
+    input.name?.trim() || null,
+    input.color?.trim() || input.category?.trim() || null
+  ].filter(Boolean)
+
+  const alt = `${fragments.join(' ')} - La Tortugueta`
+  if (typeof input.viewIndex === 'number') {
+    return `${alt} vista ${input.viewIndex + 1}`
+  }
+  return alt
+}
+
 export const buildProductBreadcrumbJsonLd = (product: Product) => ({
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
@@ -242,6 +276,11 @@ export const buildProductJsonLd = (product: Product) => {
         product.available === false
           ? 'https://schema.org/PreOrder'
           : 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/NewCondition',
+      seller: {
+        '@type': 'Organization',
+        name: 'La Tortugueta'
+      },
       url: absoluteUrl(`/${product.id}`)
     },
     mainEntityOfPage: {
@@ -304,4 +343,3 @@ export const buildBreadcrumbJsonLd = (items: { name: string; url: string }[]) =>
     item: absoluteUrl(item.url)
   }))
 })
-


### PR DESCRIPTION
## What changed

This PR bundles the current functional fixes and the highest-priority SEO/content tasks we reviewed in GitHub.

- removes the public street address from the contact experience and footer-facing contact copy
- fixes wholesale pricing in admin sales so wholesale uses 50% of the catalog price consistently
- adds a new pillar page at `/calcetines-tradicionales`
- strengthens internal linking from navigation, footer, home, colors, about, and blog
- improves product image alt text and enriches product schema metadata
- adds two Spanish blog posts linked to the new pillar page

## Why

There were two concrete product issues to solve first:

1. the contact page still exposed a physical address the team no longer wants to display publicly
2. the sales management screen was using the wrong price basis for wholesale orders

Beyond that, the repo had several open SEO/content issues. The highest-value path was to build the pillar page, support it with internal links, and add related blog content so the new page is not isolated.

## Impact

- admin sales pricing should now reflect retail vs wholesale correctly
- the public site no longer surfaces the street address in contact/footer copy
- search engines get a stronger content hub around `calcetines tradicionales valencianos`
- product and catalog imagery now use more descriptive alt text for accessibility and image SEO

## Validation

- reviewed the changed routes/components and git diff locally
- attempted `npm run build`
- build could not complete in this checkout because `next` is not installed locally (`sh: next: command not found`)

## Notes

This PR intentionally skips the Google My Business issue because we agreed not to do that one for now.